### PR TITLE
Enhancement: SAM Inference Device Optimization

### DIFF
--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -23,6 +23,7 @@ import json
 import safetensors.torch
 from PIL.PngImagePlugin import PngInfo
 import latent_preview
+import torch
 
 warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is deprecated')
 
@@ -121,6 +122,8 @@ class SAMLoader:
             model_kind = 'vit_b'
 
         sam = sam_model_registry[model_kind](checkpoint=modelname)
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        sam.to(device=device)
         print(f"Loads SAM model: {modelname}")
         return (sam, )
 

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -23,7 +23,7 @@ import json
 import safetensors.torch
 from PIL.PngImagePlugin import PngInfo
 import latent_preview
-import torch
+import comfy.model_management
 
 warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is deprecated')
 
@@ -103,15 +103,20 @@ class CLIPSegDetectorProvider:
 
 class SAMLoader:
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {"model_name": (folder_paths.get_filename_list("sams"), )}}
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_name": (folder_paths.get_filename_list("sams"), ),
+                "use_cpu": ([False, True],),
+            }
+        }
 
     RETURN_TYPES = ("SAM_MODEL", )
     FUNCTION = "load_model"
 
     CATEGORY = "ImpactPack"
 
-    def load_model(self, model_name):
+    def load_model(self, model_name, use_cpu=False):
         modelname = folder_paths.get_full_path("sams", model_name)
 
         if 'vit_h' in model_name:
@@ -122,7 +127,9 @@ class SAMLoader:
             model_kind = 'vit_b'
 
         sam = sam_model_registry[model_kind](checkpoint=modelname)
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        # Unless user explicitly wants to use CPU, we use GPU
+        device = "cpu" if use_cpu else comfy.model_management.get_torch_device()
+        print(f"Moves SAM model to device: {device}")
         sam.to(device=device)
         print(f"Loads SAM model: {modelname}")
         return (sam, )


### PR DESCRIPTION
**Description:**

This pull request introduces an effective optimization to the `SAMLoader` class in the `impact_pack.py` file.

**Discovery Process:**

While using CPU for inference on smaller images (e.g., 512x768), I didn't notice any significant efficiency issues due to the short processing time. However, when I used a high-resolution restored image (e.g., 1024x1536) for SAM segmentation, I noticed a multiple-fold increase in processing time, accompanied by an increase in the speed of my computer's fan and noise. This led me to realize that SAM was not leveraging GPU acceleration.

**Changes Made:**

I have modified the `load_model` method to automatically detect the availability of a CUDA-enabled GPU and leverage it for model inference, which can potentially speed up the inference time. If a CUDA device is not available, the model inference defaults to using the CPU.

Specifically, I added the following lines to the `load_model` method:

```python
device = "cuda" if torch.cuda.is_available() else "cpu"
sam.to(device=device)
```

**Benefits:**

This change enables the automatic selection of the optimal device for model inference without the need for manual specification by the user. It is designed to take advantage of a GPU's superior parallel processing capabilities for faster inference times with large-scale models. However, in the absence of a GPU, or when working with smaller models, the code will still function effectively by running the inference on the CPU.

**Potential Impacts:**

The introduced changes do not alter the function signature and should not break any existing dependencies or use cases. However, they may have an impact on users with low VRAM devices as the model will write into VRAM when using GPU for SAM. The required VRAM can range from 300MB to 2.6GB, depending on the size of the model chosen by the user.

I believe this enhancement will be beneficial for the efficiency and usability of the SAMLoader class. I kindly request a review of this PR and am open to further discussions or changes as necessary.

Thank you for your time and consideration.