### PR TITLE
Add the ability for wildcards to be loaded by following symlinks

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -9,7 +9,7 @@ wildcard_dict = {}
 
 def read_wildcard_dict(wildcard_path):
     global wildcard_dict
-    for root, directories, files in os.walk(wildcard_path):
+    for root, directories, files in os.walk(wildcard_path, followlinks=True):
         for file in files:
             if file.endswith('.txt'):
                 file_path = os.path.join(root, file)


### PR DESCRIPTION
The use case for symlinks:

- allows wildcard directories to be used by other SD UIs like A1111 without needing to sync everything if an update occurs
- easier resets when removing/reisntalling custom nodes; one command vs copying
- allows users to organizational structures while having all the wildcards in one place
- avoids documentation requirements for stating that you don't support symlinks

I can write up something that does a check in the config file if that is desired before activating.  For example if this ability doesn't work in Windows or is interpreted as  a security risk.  