### PR TITLE
Lora weight handling when only one weight is provided

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -116,6 +116,7 @@ def extract_lora_values(string):
         elif len(item) == 2:
             lora = item[0]
             a = safe_float(item[1])
+            b = a  # When only one weight is provided, use the same weight for model as well as clip - similar to Automatic1111
         elif len(item) >= 3:
             lora = item[0]
             if item[1] != '':


### PR DESCRIPTION
While loading lora, if only one weight is provided, use the same weight for both model as well as clip - similar to Automatic1111

**Note:** This is a breaking change. Maybe this should be handled differently(either in a major version change or through a different node)