### PR TITLE
fix: ImpactValueSender-BOOLEAN

### DIFF
--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -158,7 +158,7 @@ function valueSendHandler(event) {
                 if(typ == 'string') {
                     nodes[i].widgets[0].value = "STRING";
                 }
-                else if(typ != "boolean") {
+                else if(typ == "boolean") {
                     nodes[i].widgets[0].value = "BOOLEAN";
                 }
                 else if(typ != "number") {

--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -158,6 +158,9 @@ function valueSendHandler(event) {
                 if(typ == 'string') {
                     nodes[i].widgets[0].value = "STRING";
                 }
+                else if(typ != "boolean") {
+                    nodes[i].widgets[0].value = "BOOLEAN";
+                }
                 else if(typ != "number") {
                     nodes[i].widgets[0].value = typeof event.detail.value;
                 }


### PR DESCRIPTION
- send boolean type as 'BOOLEAN' instead of 'boolean'
- Same as the previous `string type` error