### PR TITLE
Fix libGL.so.1 missing error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ segment-anything
 scikit-image
 piexif
 transformers
+opencv-python-headless


### PR DESCRIPTION
On minimal docker container libgl1 is missing and is usually install with minimal overhead using pip install opencv-python-headless