### PR TITLE
Expose image on latent pixel space upscaling

### DIFF
--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -1312,7 +1312,7 @@ def latent_upscale_on_pixel_space_shape(samples, scale_method, w, h, vae, use_ti
     return vae_encode(vae, pixels, use_tile, hook, tile_size=tile_size)
 
 
-def latent_upscale_on_pixel_space(samples, scale_method, scale_factor, vae, use_tile=False, tile_size=512,
+def latent_upscale_on_pixel_space2(samples, scale_method, scale_factor, vae, use_tile=False, tile_size=512,
                                   save_temp_prefix=None, hook=None):
     pixels = vae_decode(vae, samples, use_tile, hook, tile_size=tile_size)
 
@@ -1326,8 +1326,11 @@ def latent_upscale_on_pixel_space(samples, scale_method, scale_factor, vae, use_
     if hook is not None:
         pixels = hook.post_upscale(pixels)
 
-    return vae_encode(vae, pixels, use_tile, hook, tile_size=tile_size)
+    return (vae_encode(vae, pixels, use_tile, hook, tile_size=tile_size), pixels)
 
+def latent_upscale_on_pixel_space(samples, scale_method, scale_factor, vae, use_tile=False, tile_size=512,
+                                  save_temp_prefix=None, hook=None):
+	return latent_upscale_on_pixel_space2(samples, scale_method, scale_factor, vae, use_tile, tile_size, save_temp_prefix, hook)[0]
 
 def latent_upscale_on_pixel_space_with_model_shape(samples, scale_method, upscale_model, new_w, new_h, vae,
                                                    use_tile=False, tile_size=512, save_temp_prefix=None, hook=None):
@@ -1356,7 +1359,7 @@ def latent_upscale_on_pixel_space_with_model_shape(samples, scale_method, upscal
     return vae_encode(vae, pixels, use_tile, hook, tile_size=tile_size)
 
 
-def latent_upscale_on_pixel_space_with_model(samples, scale_method, upscale_model, scale_factor, vae, use_tile=False,
+def latent_upscale_on_pixel_space_with_model2(samples, scale_method, upscale_model, scale_factor, vae, use_tile=False,
                                              tile_size=512, save_temp_prefix=None, hook=None):
     pixels = vae_decode(vae, samples, use_tile, hook, tile_size=tile_size)
 
@@ -1384,8 +1387,11 @@ def latent_upscale_on_pixel_space_with_model(samples, scale_method, upscale_mode
     if hook is not None:
         pixels = hook.post_upscale(pixels)
 
-    return vae_encode(vae, pixels, use_tile, hook, tile_size=tile_size)
+    return (vae_encode(vae, pixels, use_tile, hook, tile_size=tile_size), pixels)
 
+def latent_upscale_on_pixel_space_with_model(samples, scale_method, upscale_model, scale_factor, vae, use_tile=False,
+                                             tile_size=512, save_temp_prefix=None, hook=None):
+	return latent_upscale_on_pixel_space_with_model2(samples, scale_method, upscale_model, scale_factor, vae, use_tile, tile_size, save_temp_prefix, hook)[0]
 
 class TwoSamplersForMaskUpscaler:
     params = None

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -483,17 +483,17 @@ class LatentPixelScale:
                     }
                 }
 
-    RETURN_TYPES = ("LATENT",)
+    RETURN_TYPES = ("LATENT","IMAGE")
     FUNCTION = "doit"
 
     CATEGORY = "ImpactPack/Upscale"
 
     def doit(self, samples, scale_method, scale_factor, vae, use_tiled_vae, upscale_model_opt=None):
         if upscale_model_opt is None:
-            latent = core.latent_upscale_on_pixel_space(samples, scale_method, scale_factor, vae, use_tile=use_tiled_vae)
+            latimg = core.latent_upscale_on_pixel_space2(samples, scale_method, scale_factor, vae, use_tile=use_tiled_vae)
         else:
-            latent = core.latent_upscale_on_pixel_space_with_model(samples, scale_method, upscale_model_opt, scale_factor, vae, use_tile=use_tiled_vae)
-        return (latent,)
+            latimg = core.latent_upscale_on_pixel_space_with_model2(samples, scale_method, upscale_model_opt, scale_factor, vae, use_tile=use_tiled_vae)
+        return latimg
 
 
 class NoiseInjectionDetailerHookProvider:


### PR DESCRIPTION
This PR adds the IMAGE as an output to the "Latent Scale (on Pixel Space)" node, which is already calculated anyway.

My main motivation is to use ControlNet on the upscaled image, for which we need the pixels to feed into the preprocessors:

<img width="1423" alt="brave_5VmAukUVXe" src="https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/634365/0f0e3021-f86a-4fef-9412-779f3f49a1fa">

From my limited understanding of both ComfyUI and python, this change should not break anything.