### PR TITLE
Remove PIL conversions to support float and uint16

### DIFF
--- a/modules/impact/hf_nodes.py
+++ b/modules/impact/hf_nodes.py
@@ -138,7 +138,7 @@ class SEGS_Classify:
                 cropped_image = crop_image(ref_image_opt, seg.crop_region)
 
             if cropped_image is not None:
-                cropped_image = Image.fromarray(np.clip(255. * cropped_image.squeeze(), 0, 255).astype(np.uint8))
+                cropped_image = to_pil(cropped_image)
                 res = classifier(cropped_image)
                 classified.append((seg, res))
             else:

--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -225,7 +225,6 @@ async def segs_picker(request):
 
     if node_id in segs_picker_map and idx < len(segs_picker_map[node_id]):
         img = to_tensor(segs_picker_map[node_id][idx]).permute(0, 3, 1, 2).squeeze(0)
-        img = (255 * img).type('uint8')
         pil = torchvision.transforms.ToPILImage('RGB')(img)
 
         image_bytes = BytesIO()

--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -7,11 +7,11 @@ import impact
 import server
 import folder_paths
 
-import torch
 import torchvision
 
 import impact.core as core
 import impact.impact_pack as impact_pack
+from impact.utils import to_tensor
 from segment_anything import SamPredictor, sam_model_registry
 import numpy as np
 import nodes
@@ -224,10 +224,13 @@ async def segs_picker(request):
     idx = int(request.rel_url.query.get('idx', ''))
 
     if node_id in segs_picker_map and idx < len(segs_picker_map[node_id]):
-        image_bytes = BytesIO()
-        torch.save(torchvision.io.encode_png(segs_picker_map[node_id][idx]), image_bytes)
-        image_bytes.seek(0)
+        img = to_tensor(segs_picker_map[node_id][idx]).permute(0, 3, 1, 2).squeeze(0)
+        img = (255 * img).type('uint8')
+        pil = torchvision.transforms.ToPILImage('RGB')(img)
 
+        image_bytes = BytesIO()
+        pil.save(image_bytes, format="PNG")
+        image_bytes.seek(0)
         return web.Response(status=200, body=image_bytes, content_type='image/png', headers={"Content-Disposition": f"filename={node_id}{idx}.png"})
 
     return web.Response(status=400)

--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -7,6 +7,9 @@ import impact
 import server
 import folder_paths
 
+import torch
+import torchvision
+
 import impact.core as core
 import impact.impact_pack as impact_pack
 from segment_anything import SamPredictor, sam_model_registry
@@ -221,10 +224,8 @@ async def segs_picker(request):
     idx = int(request.rel_url.query.get('idx', ''))
 
     if node_id in segs_picker_map and idx < len(segs_picker_map[node_id]):
-        pil = segs_picker_map[node_id][idx]
-
         image_bytes = BytesIO()
-        pil.save(image_bytes, format="PNG")
+        torch.save(torchvision.io.encode_png(segs_picker_map[node_id][idx]), image_bytes)
         image_bytes.seek(0)
 
         return web.Response(status=200, body=image_bytes, content_type='image/png', headers={"Content-Disposition": f"filename={node_id}{idx}.png"})


### PR DESCRIPTION
# Support float and uint16

## Summary

Resolve #369 

- Usage of pil conversion for network input remains untouched. Only affects node outputs.
- Only affects `image`s, not `mask`s or `seg`s. `seg` and `mask` related codes involving `np.uint8` remains untouched.
- Methods in `PIL.Image.XX` is implemented for `torch.Tensor`, with method name `utils.tensor_XX`.
  - e.g. `image1.paste(image2, xy, mask)` -> `tensor_paste(image1, image2, xy, mask)`
- Some unused methods remains untouched. They are used in `onnx` or `subcore` package, and should be moved there imo.
  - e.g. `tensor2pil`

## Test

Testing using the workflows in [tutorial](https://github.com/ltdrdata/ComfyUI-extension-tutorials/tree/Main/ComfyUI-Impact-Pack/tutorial).
Run through the whole list until no test fails.

(I noticed good documentation. Good job👏)

<details>
  <summary>pip list</summary>

```
Package                  Version
------------------------ --------------------
absl-py                  2.0.0
accelerate               0.25.0
addict                   2.4.0
aiohttp                  3.9.1
aiosignal                1.3.1
antlr4-python3-runtime   4.9.3
async-timeout            4.0.3
attrs                    23.1.0
certifi                  2023.11.17
cffi                     1.16.0
chardet                  5.2.0
charset-normalizer       3.3.2
coloredlogs              15.0.1
contourpy                1.2.0
cssselect2               0.7.0
cycler                   0.12.1
einops                   0.7.0
filelock                 3.13.1
flatbuffers              23.5.26
fonttools                4.46.0
frozenlist               1.4.0
fsspec                   2023.12.2
ftfy                     6.1.3
fvcore                   0.1.5.post20221221
git-python               1.0.3
gitdb                    4.0.11
GitPython                3.1.40
huggingface-hub          0.19.4
humanfriendly            10.0
idna                     3.6
imageio                  2.33.1
imageio-ffmpeg           0.4.9
importlib-metadata       7.0.0
iopath                   0.1.10
Jinja2                   3.1.2
kiwisolver               1.4.5
lazy_loader              0.3
lxml                     4.9.3
MarkupSafe               2.1.3
matplotlib               3.8.2
mediapipe                0.10.9
mpmath                   1.3.0
multidict                6.0.4
networkx                 3.2.1
numpy                    1.26.2
nvidia-cublas-cu12       12.1.3.1
nvidia-cuda-cupti-cu12   12.1.105
nvidia-cuda-nvrtc-cu12   12.1.105
nvidia-cuda-runtime-cu12 12.1.105
nvidia-cudnn-cu12        8.9.2.26
nvidia-cufft-cu12        11.0.2.54
nvidia-curand-cu12       10.3.2.106
nvidia-cusolver-cu12     11.4.5.107
nvidia-cusparse-cu12     12.1.0.106
nvidia-nccl-cu12         2.18.1
nvidia-nvjitlink-cu12    12.3.101
nvidia-nvtx-cu12         12.1.105
omegaconf                2.3.0
onnxruntime              1.16.3
onnxruntime-gpu          1.16.3
opencv-contrib-python    4.8.1.78
opencv-python            4.8.1.78
opencv-python-headless   4.8.1.78
packaging                23.2
pandas                   2.1.4
piexif                   1.1.3
Pillow                   10.1.0
pip                      23.3.1
platformdirs             4.1.0
portalocker              2.8.2
protobuf                 3.20.3
psutil                   5.9.6
py-cpuinfo               9.0.0
pycparser                2.21
pyparsing                3.1.1
python-dateutil          2.8.2
pytz                     2023.3.post1
PyYAML                   6.0.1
regex                    2023.10.3
reportlab                4.0.8
requests                 2.31.0
safetensors              0.4.1
scikit-image             0.22.0
scipy                    1.11.4
seaborn                  0.13.0
segment-anything         1.0
setuptools               58.1.0
six                      1.16.0
smmap                    5.0.1
sounddevice              0.4.6
svglib                   1.5.1
sympy                    1.12
tabulate                 0.9.0
termcolor                2.4.0
thop                     0.1.1.post2209072238
tifffile                 2023.12.9
tinycss2                 1.2.1
tokenizers               0.15.0
tomli                    2.0.1
torch                    2.1.1
torchsde                 0.2.6
torchvision              0.16.1
tqdm                     4.66.1
trampoline               0.1.2
transformers             4.36.1
triton                   2.1.0
typing_extensions        4.9.0
tzdata                   2023.3
ultralytics              8.0.227
urllib3                  2.1.0
wcwidth                  0.2.12
webencodings             0.5.1
yacs                     0.1.8
yapf                     0.40.2
yarl                     1.9.4
zipp                     3.17.0
```
</details>

<details>
  <summary>custom nodes</summary>

```
$ ls custom_nodes/
ComfyUI-AnimateDiff-Evolved  ComfyUI-SDXL-EmptyLatentImage  ComfyUI_SeeCoder            __pycache__
ComfyUI-Custom-Scripts       ComfyUI-VideoHelperSuite       ComfyUI_TiledKSampler       clipseg.py
ComfyUI-Impact-Pack          ComfyUI-Workflow-Component     ComfyUI_essentials          comfyui_controlnet_aux
ComfyUI-Inspire-Pack         ComfyUI_Cutoff                 ComfyUI_experiments         example_node.py.example
ComfyUI-Manager              ComfyUI_Noise                  Derfuu_ComfyUI_ModdedNodes  sdxl_prompt_styler
```
Note that official ComfyUI_Noise has a bug. For this test, I used https://github.om/ltdrdata/ComfyUI_Noise/tree/fix/unsampler-noise-mask
</details>

<details>
<summary>Models&Weights</summary>


| Model | Weight Name | SHA256 |
|---|---|---|
| Checkpoint | Swizz8-XART-BakedVAE-FP16-Pruned.safetensors | 28f041948673a65f1931cab57e828d61bddaf229c9ddccf610816eebbc77c474 |
| Checkpoint | SDXL 1.0 | e6bb9ea85bbf7bf6478a7c6d18b71246f22e95d41bcdd80ed40aa212c33cfeff |
| Upscale | RealESRGAN_x2plus.pth | 49fafd45f8fd7aa8d31ab2a22d14d91b536c34494a5cfe31eb5d89c2fa266abb |
| ControlNet (Canny) | - | e19821a00e6d1817b37286a21d5c4f8915076949b0e81846c4f92c96ffb46db7 |
| ControlNet (OpenPose) | openpose.fp16.safetensors | b25b1125e870275550b2a7de289056cb3c236c01c293bd5ba883657b1c006e3e | 
| LoRA | flat_color.pt | e91f4a528578921540a1dbcd802bb5ca8f7f51cb30309ccadae6e20b802080bc |

</details>

| Workflow Name | Result | Comment |
| --- | --- | --- |
| `advanced-simple.json` | ✅ ||
| `clipseg.json` | ✅ ||
| `crowd-face.json` | ✅ ||
| `detailer-wildcard.json` | ✅ ||
|`dwpose-segs-handfix.json`| ⚠️ | `cnet_image` on `DetailerDebug(SEGS/pipe)` not showing. Also present in `Main` `6e11efd7`)|
|`hair-restyle.json`| ✅ ||
|`interactive-sam.json`| ✅ ||
|`inversed-switch.json`| ✅ ||
|`maskpointer.json`| ✅ ||
|`mediapipe-detector.json`| ✅ ||
|`multibatch.json`| ✅ ||
|`onnx.json`| ✅ | |
|`pipe-refine.json`| ✅ ||
|`pk_hook.json`| ✅ ||
|`pk_hook2.json`| ✅ | One `PixelTiledKSampleUpscalerProviderPipe` node was on mode `Never`. Tested after changing it to `Always`. |
|`regional-loras.json`| ⚠️ | When run with SDXL checkpoint and SD1.5 LoRA, the error message is obfuscated. `RuntimeError: mat1 and mat2 shapes cannot be multiplied (154x2048 and 768x320)`. |
|`regionalsampling.json`| ✅ ||
|`sdxl-detailer.json`| ✅ ||
|`segs-manipulation.json`| ✅ | `From_SEG_ELT.doit() missing 1 required positional argument: 'seg_elt'`. Also present in `Main` `6e11efd7`) |
|`segs-picker.json`|⚠️| It passes. But does `alpha=255` make sense with `float`? Currently is normalizing by `/255`. |
|`simple.json`| ✅ ||
|`switch.json`| ✅ ||
|`TwoSamplersForMask.json`| ✅ ||
|`TwoSamplersForMaskUpscaler.json`| ✅ | 2d mask issue is fixed. This test fails in `Main` `6e11efd7`) |
|`upscale.json`| ✅ ||
|`wildcard-lbw.json`|✅||
|`wildcard-prompt-styler.json`|✅||