### PR TITLE
Make LoRA CLIP strength default to model strength in ImpactWildcardEncode

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -265,7 +265,7 @@ def extract_lora_values(string):
         if a is None:
             a = 1.0
         if b is None:
-            b = 1.0
+            b = a
 
         if lora is not None and lora not in added:
             result.append((lora, a, b, lbw, lbw_a, lbw_b))


### PR DESCRIPTION
I noticed while using ImpactWildcardEncode that if a LoRA's CLIP strength was not explicitly defined (i.e. if one said `<lora:XXX:0.8>` instead of `<lora:XXX:0.8:0.8>`), the CLIP strength would default to 1.0. My personal expectation is that, in that situation, it would behave more like A1111, where the CLIP strength is always identical to the model strength (since they cannot be separated). I decided to fix this by setting the CLIP strength to the model strength if it is not provided.

I have been using this tweak for a while, and it works quite well, so I decided to submit a pull request to add it to the main repo.