### PR TITLE
Add 'GitPython' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scikit-image
 piexif
 transformers
 opencv-python-headless
+GitPython


### PR DESCRIPTION
By default, the installation fails if the user does not have the `git` module installed. I think adding this to the `requirements.txt` might make the process a bit smoother for future users.