### PR TITLE
Add an ImpactLatentInfo node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -288,6 +288,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactValueSender": ImpactValueSender,
     "ImpactValueReceiver": ImpactValueReceiver,
     "ImpactImageInfo": ImpactImageInfo,
+    "ImpactLatentInfo": ImpactLatentInfo,
     "ImpactMinMax": ImpactMinMax,
     "ImpactNeg": ImpactNeg,
     "ImpactConditionalStopIteration": ImpactConditionalStopIteration,

--- a/modules/impact/logics.py
+++ b/modules/impact/logics.py
@@ -248,6 +248,26 @@ class ImpactImageInfo:
         return (value.shape[0], value.shape[1], value.shape[2], value.shape[3])
 
 
+class ImpactLatentInfo:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+                    "value": ("LATENT", ),
+                    },
+                }
+
+    FUNCTION = "doit"
+
+    CATEGORY = "ImpactPack/Logic/_for_test"
+
+    RETURN_TYPES = ("INT", "INT", "INT", "INT")
+    RETURN_NAMES = ("batch", "height", "width", "channel")
+
+    def doit(self, value):
+        shape = value['samples'].shape
+        return (shape[0], shape[2] * 8, shape[3] * 8, shape[1])
+
+
 class ImpactMinMax:
     @classmethod
     def INPUT_TYPES(cls):


### PR DESCRIPTION
I find the ImpactImageInfo node to be quite useful, and decided to add a counterpart for latents, so I did not have to decode the latent just to get its size if I wanted to.

I know the branch history is a little messy; I actually made this a few days ago, but didn't want to spam multiple pull requests in one day, so I waited until my other branch was merged. Then many changes were made in the interim before I ended up submitting this request, so I decided to rebase it to the current master to make things easier, and... well, I ended up making the history a little confusing. Hopefully it does not prove to be an issue.