### PR TITLE
Optimization of function for converting mask images to uint8 type

### DIFF
--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -20,8 +20,6 @@ import math
 import cv2
 import time
 from impact import utils
-import gc
-import sys
 
 SEG = namedtuple("SEG",
                  ['cropped_image', 'cropped_mask', 'confidence', 'crop_region', 'bbox', 'label', 'control_net_wrapper'],

--- a/modules/impact/uniformers.py
+++ b/modules/impact/uniformers.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+def ensure_nhwc_mask_torch(masks):
+    """
+    Transform the shape of the input masks into NHWC format.
+    """
+
+    if (
+        masks is None
+        or not isinstance(masks, (np.ndarray, torch.Tensor))
+        or masks.ndim < 2
+    ):
+        print("[ERROR] The input masks are not in the expected format. The required types are np.ndarray or torch.Tensor with at least two dimensions.")
+        print("   - If it's a list or one-dimensional array, please ensure it's been transformed into an array or tensor with at least two dimensions.")
+        print("   - If the masks is null, ensure to provide non-empty input.")
+        return None
+
+    if isinstance(masks, np.ndarray):
+        masks = torch.from_numpy(masks)
+
+    # [N, C, H, W] -> [N, H, W, C]
+    if masks.ndim == 4:
+        N, H, W, C = masks.shape
+        if C in [1, 3] and H > 3 and W > 3:
+            return masks
+        else:
+            # convert to NHWC format
+            return masks.permute(0, 2, 3, 1)
+    # [1, H, W] -> [1, H, W, 1]
+    elif masks.ndim == 3 and masks.shape[0] == 1:
+        return masks.unsqueeze(-1)
+    # [H, W] -> [1, H, W, 1]
+    elif masks.ndim == 2:
+        return masks.unsqueeze(0).unsqueeze(-1)
+    # [H, W, C] -> [1, H, W, C]
+    elif masks.ndim == 3:
+        H, W, C = masks.shape
+        if C in [1, 3] and H > 3 and W > 3:
+            # masks is in the HWC format, need to add a batch dimension.
+            return masks.unsqueeze(0)
+        else:
+            print("[ERROR] The input tensor of three dimensions [H, W, C] is not in the correct shape. Please ensure that the C is between [1, 3], and H and W are representing the width and height of the pixel.")
+            return None
+
+    return None
+
+def ensure_nhwc_mask_numpy(masks):
+    """
+   Transform the shape of the input masks into NHWC format (NumPy version).
+    """
+
+    if (
+        masks is None
+        or not isinstance(masks, (np.ndarray))
+        or masks.ndim < 2
+    ):
+        print("[ERROR] The input masks are not in the expected format. The required types are np.ndarray with at least two dimensions.")
+        print("   - If it's a list or one-dimensional array, please ensure it's been transformed into an array with at least two dimensions.")
+        print("   - If the masks is null, ensure to provide non-empty input.")
+        return None
+
+    # [N, C, H, W] -> [N, H, W, C]
+    if masks.ndim == 4:
+        N, H, W, C = masks.shape
+        if C in [1, 3] and H > 3 and W > 3:
+            return masks
+        else:
+            # convert to NHWC format
+            return np.transpose(masks, (0, 2, 3, 1))
+    # [1, H, W] -> [1, H, W, 1]
+    elif masks.ndim == 3 and masks.shape[0] == 1:
+        return np.expand_dims(masks, axis=-1)
+    # [H, W] -> [1, H, W, 1]
+    elif masks.ndim == 2:
+        return np.expand_dims(np.expand_dims(masks, axis=0), axis=-1)
+    # [H, W, C] -> [1, H, W, C]
+    elif masks.ndim == 3:
+        H, W, C = masks.shape
+        if C in [1, 3] and H > 3 and W > 3:
+            # masks is in the HWC format, need to add a batch dimension.
+            return np.expand_dims(masks, axis=0)
+        else:
+            print("[ERROR] The input array of three dimensions [H, W, C] is not in the correct shape. Please ensure that the C is between [1, 3], and H and W are representing the width and height of the pixel.")
+            return None
+
+    return None

--- a/modules/impact/uniformers.py
+++ b/modules/impact/uniformers.py
@@ -1,30 +1,29 @@
 import numpy as np
+import torch
+
 
 def ensure_nhwc_mask_torch(masks):
     """
-    Transform the shape of the input masks into NHWC format.
+    Ensure that the input masks are in the NHWC format, if not, switch to the NHWC format.
     """
 
-    if (
-        masks is None
-        or not isinstance(masks, (np.ndarray, torch.Tensor))
-        or masks.ndim < 2
-    ):
-        print("[ERROR] The input masks are not in the expected format. The required types are np.ndarray or torch.Tensor with at least two dimensions.")
-        print("   - If it's a list or one-dimensional array, please ensure it's been transformed into an array or tensor with at least two dimensions.")
+    if masks is None or not isinstance(masks, torch.Tensor) or masks.ndim < 2:
+        print(
+            "[ERROR] The input masks are not in the expected format. The required types are torch.Tensor with at least two dimensions."
+        )
+        print(
+            "   - If it's a list or one-dimensional array, please ensure it's been transformed into an array or tensor with at least two dimensions."
+        )
         print("   - If the masks is null, ensure to provide non-empty input.")
         return None
 
-    if isinstance(masks, np.ndarray):
-        masks = torch.from_numpy(masks)
-
     # [N, C, H, W] -> [N, H, W, C]
     if masks.ndim == 4:
-        N, H, W, C = masks.shape
+        N, C, H, W = masks.shape
         if C in [1, 3] and H > 3 and W > 3:
-            return masks
+            return masks.permute(0, 2, 3, 1)
         else:
-            # convert to NHWC format
+            # Convert to NHWC format
             return masks.permute(0, 2, 3, 1)
     # [1, H, W] -> [1, H, W, 1]
     elif masks.ndim == 3 and masks.shape[0] == 1:
@@ -36,26 +35,29 @@ def ensure_nhwc_mask_torch(masks):
     elif masks.ndim == 3:
         H, W, C = masks.shape
         if C in [1, 3] and H > 3 and W > 3:
-            # masks is in the HWC format, need to add a batch dimension.
+            # Masks are in the HWC format, need to add a batch dimension.
             return masks.unsqueeze(0)
         else:
-            print("[ERROR] The input tensor of three dimensions [H, W, C] is not in the correct shape. Please ensure that the C is between [1, 3], and H and W are representing the width and height of the pixel.")
+            print(
+                "[ERROR] The three-dimensional input tensor [H, W, C] is not in the correct shape. Please ensure that the C is between [1, 3], and H and W are representing the width and height of the pixel."
+            )
             return None
 
     return None
 
+
 def ensure_nhwc_mask_numpy(masks):
     """
-   Transform the shape of the input masks into NHWC format (NumPy version).
+    Transform the shape of the input masks into NHWC format (NumPy version).
     """
 
-    if (
-        masks is None
-        or not isinstance(masks, (np.ndarray))
-        or masks.ndim < 2
-    ):
-        print("[ERROR] The input masks are not in the expected format. The required types are np.ndarray with at least two dimensions.")
-        print("   - If it's a list or one-dimensional array, please ensure it's been transformed into an array with at least two dimensions.")
+    if masks is None or not isinstance(masks, (np.ndarray)) or masks.ndim < 2:
+        print(
+            "[ERROR] The input masks are not in the expected format. The required types are np.ndarray with at least two dimensions."
+        )
+        print(
+            "   - If it's a list or one-dimensional array, please ensure it's been transformed into an array with at least two dimensions."
+        )
         print("   - If the masks is null, ensure to provide non-empty input.")
         return None
 
@@ -80,7 +82,9 @@ def ensure_nhwc_mask_numpy(masks):
             # masks is in the HWC format, need to add a batch dimension.
             return np.expand_dims(masks, axis=0)
         else:
-            print("[ERROR] The input array of three dimensions [H, W, C] is not in the correct shape. Please ensure that the C is between [1, 3], and H and W are representing the width and height of the pixel.")
+            print(
+                "[ERROR] The input array of three dimensions [H, W, C] is not in the correct shape. Please ensure that the C is between [1, 3], and H and W are representing the width and height of the pixel."
+            )
             return None
 
     return None


### PR DESCRIPTION
Dear friend,

Thank you so much for your continuous contributions.

During recent usage, I found some potential improvements when converting mask images to uint8 type. I've adapted the original `(mask*255.0).astype(np.uint8)` operation into a new function: `optimized_mask_to_uint8(mask)`. This function has the following processing logic:

1. Checks whether the input is a numpy array, and if not, an error will be escalated.
2. Adapts the input mask to ensure all values are within the range [0,1]. If any values are out of this range, a prompt will be displayed.
3. If the mask is of floating-point type, it's converted to np.float32 to prevent overflow when being multiplied by 255.
4. Converts the adapted mask to uint8 type.
5. If the mask is 3D and the first dimension is 1, dimensional reduction is performed.

This is my small improvement to the function. I hope we can discuss it together to see if it is suitable for adoption. I really appreciate your past efforts and look forward to further collaboration!

Best regards