### PR TITLE
Revert `cond` of `ImpactConditionalBranch` to widget

### DIFF
--- a/modules/impact/logics.py
+++ b/modules/impact/logics.py
@@ -63,7 +63,7 @@ class ImpactConditionalBranch:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "cond": ("BOOLEAN", {"forceInput": True}),
+                "cond": ("BOOLEAN",),
                 "tt_value": (any_typ,),
                 "ff_value": (any_typ,),
             },


### PR DESCRIPTION
I think `cond` of `ImpactConditionalBranch` would be better as a widget, it can be used as a cleaner switch, and can be correctly converted to group nodes