### PR TITLE
Add "ControlnetApplyAdvanced (SEGS)" node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -211,6 +211,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactSimpleDetectorSEGS": SimpleDetectorForEach,
     "ImpactSimpleDetectorSEGSPipe": SimpleDetectorForEachPipe,
     "ImpactControlNetApplySEGS": ControlNetApplySEGS,
+    "ImpactControlNetApplyAdvancedSEGS": ControlNetApplyAdvancedSEGS,
     "ImpactControlNetClearSEGS": ControlNetClearSEGS,
 
     "ImpactDecomposeSEGS": DecomposeSEGS,
@@ -329,6 +330,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ImpactSimpleDetectorSEGS": "Simple Detector (SEGS)",
     "ImpactSimpleDetectorSEGSPipe": "Simple Detector (SEGS/pipe)",
     "ImpactControlNetApplySEGS": "ControlNetApply (SEGS)",
+    "ImpactControlNetApplyAdvancedSEGS": "ControlNetApplyAdvanced (SEGS)",
 
     "BboxDetectorCombined_v2": "BBOX Detector (combined)",
     "SegmDetectorCombined_v2": "SEGM Detector (combined)",

--- a/modules/impact/segs_nodes.py
+++ b/modules/impact/segs_nodes.py
@@ -1202,6 +1202,40 @@ class ControlNetApplySEGS:
         return ((segs[0], new_segs), )
 
 
+class ControlNetApplyAdvancedSEGS:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+                    "segs": ("SEGS",),
+                    "control_net": ("CONTROL_NET",),
+                    "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01}),
+                    "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+                    "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001})
+                    },
+                "optional": {
+                    "segs_preprocessor": ("SEGS_PREPROCESSOR",),
+                    "control_image": ("IMAGE",)
+                    }
+                }
+
+    RETURN_TYPES = ("SEGS",)
+    FUNCTION = "doit"
+
+    CATEGORY = "ImpactPack/Util"
+
+    def doit(self, segs, control_net, strength, start_percent, end_percent, segs_preprocessor=None, control_image=None):
+        new_segs = []
+
+        for seg in segs[1]:
+            control_net_wrapper = core.ControlNetAdvancedWrapper(control_net, strength, start_percent, end_percent, segs_preprocessor,
+                                                                 seg.control_net_wrapper, original_size=segs[0], crop_region=seg.crop_region,
+                                                                 control_image=control_image)
+            new_seg = SEG(seg.cropped_image, seg.cropped_mask, seg.confidence, seg.crop_region, seg.bbox, seg.label, control_net_wrapper)
+            new_segs.append(new_seg)
+
+        return ((segs[0], new_segs), )
+
+
 class ControlNetClearSEGS:
     @classmethod
     def INPUT_TYPES(s):


### PR DESCRIPTION
Hello! 

I've added a wrapper node for ControlNetApplyAdvanced that allows editing the start and end percentages and also applies to the negative conditioning on top of the positive (untangling these features would require implementing a separate controlnet path, as ComfyUI's "ControlNetAdvanced" implementation requires both.)

I am not super-confident my implementation is proper, but I can at least confirm that it works on the workflows I've tested. I had to make some edits to the existing ControlNetApplySEGS and enhance_detail method to retain controlnet chaining compatibility with the new node. Please let me know if there's anything I need to change or if this is unnecessary