### PR TITLE
Improve `ImpactConditionalBranch`

### DIFF
--- a/modules/impact/logics.py
+++ b/modules/impact/logics.py
@@ -62,11 +62,11 @@ class ImpactConditionalBranch:
     @classmethod
     def INPUT_TYPES(cls):
         return {
-            "required": {
-                "cond": ("BOOLEAN",),
+            "required": {"cond": ("BOOLEAN",),},
+            "optional":{
                 "tt_value": (any_typ,),
                 "ff_value": (any_typ,),
-            },
+            }
         }
 
     FUNCTION = "doit"
@@ -74,10 +74,14 @@ class ImpactConditionalBranch:
 
     RETURN_TYPES = (any_typ, )
 
-    def doit(self, cond, tt_value, ff_value):
+    def doit(self, cond, tt_value=None, ff_value=None):
         if cond:
+            if tt_value is None:
+                tt_value = ff_value
             return (tt_value,)
         else:
+            if ff_value is None:
+                ff_value = tt_value
             return (ff_value,)
 
 
@@ -103,8 +107,12 @@ class ImpactConditionalBranchSelMode:
     def doit(self, cond, sel_mode, tt_value=None, ff_value=None):
         print(f'tt={tt_value is None}\nff={ff_value is None}')
         if cond:
+            if tt_value is None:
+                tt_value = ff_value
             return (tt_value,)
         else:
+            if ff_value is None:
+                ff_value = tt_value
             return (ff_value,)
 
 


### PR DESCRIPTION
I want to add the function of "determining whether the value is None" to `ImpactConditionalBranch`.
When the selected input is None, output another value.

![2024-01-27 150503](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/89350747/78c77fcf-8bc1-4dea-9671-d8fde10cfbed)

![2024-01-27 150544](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/89350747/3ad343dd-32de-4543-842c-1620d3e437c5)

However, it does not work as expected in `ImpactConditionalBranchSelMode`. When the selected output is None, the other value of the output also becomes None.

![2024-01-27 150638](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/89350747/7e29a3de-0b9a-494a-a624-6ad8bc1e12ac)

please help fix it