### PR TITLE
feat: ImpactLogicalOperators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -293,6 +293,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactConditionalBranchSelMode": ImpactConditionalBranchSelMode,
     "ImpactIfNone": ImpactIfNone,
     "ImpactConvertDataType": ImpactConvertDataType,
+    "ImpactLogicalOperators": ImpactLogicalOperators,
     "ImpactInt": ImpactInt,
     "ImpactFloat": ImpactFloat,
     "ImpactValueSender": ImpactValueSender,

--- a/modules/impact/logics.py
+++ b/modules/impact/logics.py
@@ -162,6 +162,31 @@ class ImpactIfNone:
             return (signal, True, )
 
 
+class ImpactLogicalOperators:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "operator": (['and', 'or', 'xor'],),
+                "bool_a": ("BOOLEAN", {"forceInput": True}),
+                "bool_b": ("BOOLEAN", {"forceInput": True}),
+            },
+        }
+
+    FUNCTION = "doit"
+    CATEGORY = "ImpactPack/Logic"
+
+    RETURN_TYPES = ("BOOLEAN", )
+
+    def doit(self, operator, bool_a, bool_b):
+        if operator == "and":
+            return (bool_a and bool_b, )
+        elif operator == "or":
+            return (bool_a or bool_b, )
+        else:
+            return (bool_a != bool_b, )
+
+
 class ImpactConditionalStopIteration:
     @classmethod
     def INPUT_TYPES(cls):


### PR DESCRIPTION
Add `ImpactLogicalOperators` node, It can do some simple logical operations.
and:
![image](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/89350747/9c3f5fa6-52b3-4ce6-8ded-cba6b4a4416e)
or:
![image](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/89350747/fa5ea71b-8ed1-418b-af2e-060080c16a4c)
xor:
![image](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/89350747/a7a14552-f67d-4b97-9662-8fbb86c9ebc9)

There is no `not` operator, because `ImpactNeg` has the same effect as `not`


