### PR TITLE
New node SEGSLabelAssign for manually assigning labels to SEGS + fix two bugs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -286,6 +286,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactCombineConditionings": CombineConditionings,
     "ImpactConcatConditionings": ConcatConditionings,
 
+    "ImpactSEGSLabelAssign": SEGSLabelAssign,
     "ImpactSEGSLabelFilter": SEGSLabelFilter,
     "ImpactSEGSRangeFilter": SEGSRangeFilter,
     "ImpactSEGSOrderedFilter": SEGSOrderedFilter,
@@ -385,6 +386,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 
     "ImpactKSamplerBasicPipe": "KSampler (pipe)",
     "ImpactKSamplerAdvancedBasicPipe": "KSampler (Advanced/pipe)",
+    "ImpactSEGSLabelAssign": "SEGS Assign (label)",
     "ImpactSEGSLabelFilter": "SEGS Filter (label)",
     "ImpactSEGSRangeFilter": "SEGS Filter (range)",
     "ImpactSEGSOrderedFilter": "SEGS Filter (ordered)",

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -238,7 +238,7 @@ class DetailerForEach:
                 cropped_mask = None
 
             if wildcard_chooser is not None:
-                seg_seed, wildcard_item = wildcard_chooser.get(seg)
+                seg_seed, wildcard_item = None, wildcard_chooser.get(seg)
             else:
                 seg_seed, wildcard_item = None, None
 
@@ -272,7 +272,7 @@ class DetailerForEach:
                 # Convert enhanced_pil_alpha to RGBA mode
                 enhanced_image_alpha = tensor_convert_rgba(enhanced_image)
                 new_seg_image = enhanced_image.numpy()  # alpha should not be applied to seg_image
-                
+
                 # Apply the mask
                 mask = tensor_resize(mask, *tensor_get_size(enhanced_image))
                 tensor_putalpha(enhanced_image_alpha, mask)
@@ -1475,7 +1475,7 @@ class SegsBitwiseAndMask:
 
     def doit(self, segs, mask):
         return (core.segs_bitwise_and_mask(segs, mask), )
-    
+
 
 class SegsBitwiseAndMaskForEach:
     @classmethod
@@ -1650,7 +1650,7 @@ class SubtractMask:
                         "mask2": ("MASK", ),
                       }
                 }
-    
+
     RETURN_TYPES = ("MASK",)
     FUNCTION = "doit"
 
@@ -1781,7 +1781,7 @@ class ImageReceiver:
                 return hash(image_data)
             else:
                 return hash(image)
-                
+
 
 from server import PromptServer
 

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -237,7 +237,9 @@ class DetailerForEach:
             else:
                 cropped_mask = None
 
-            if wildcard_chooser is not None:
+            if wildcard_chooser is not None and wmode != "LAB":
+                seg_seed, wildcard_item = wildcard_chooser.get(seg)
+            elif wildcard_chooser is not None and wmode == "LAB":
                 seg_seed, wildcard_item = None, wildcard_chooser.get(seg)
             else:
                 seg_seed, wildcard_item = None, None

--- a/modules/impact/mmdet_nodes.py
+++ b/modules/impact/mmdet_nodes.py
@@ -1,5 +1,6 @@
 import folder_paths
 from impact.core import *
+import os
 
 import mmcv
 from mmdet.apis import (inference_detector, init_detector)

--- a/modules/impact/segs_nodes.py
+++ b/modules/impact/segs_nodes.py
@@ -415,6 +415,44 @@ class SEGSLabelFilter:
         return SEGSLabelFilter.filter(segs, labels)
 
 
+class SEGSLabelAssign:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+                        "segs": ("SEGS", ),
+                        "labels": ("STRING", {"multiline": True, "placeholder": "List the label to be assigned in order of segs, separated by commas"}),
+                     },
+                }
+
+    RETURN_TYPES = ("SEGS",)
+    RETURN_NAMES = ("SEGS",)
+    FUNCTION = "doit"
+
+    CATEGORY = "ImpactPack/Util"
+
+    @staticmethod
+    def assign(segs, labels):
+        labels = [label.strip() for label in labels]
+
+        if len(labels) != len(segs[1]):
+            print(f'Warning (SEGSLabelAssign): length of labels ({len(labels)}) != length of segs ({len(segs[1])})')
+
+        labeled_segs = []
+
+        idx = 0
+        for x in segs[1]:
+            if len(labels) > idx:
+                x = x._replace(label=labels[idx])
+            labeled_segs.append(x)
+            idx += 1
+
+        return ((segs[0], labeled_segs), )
+
+    def doit(self, segs, labels):
+        labels = labels.split(',')
+        return SEGSLabelAssign.assign(segs, labels)
+
+
 class SEGSOrderedFilter:
     @classmethod
     def INPUT_TYPES(s):


### PR DESCRIPTION
I was recently working with labels in the detailer wildcard prompt as described [here](https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/ImpactWildcard.md#special-syntax-for-detailer-wildcard). For my workflow I needed support of manually assigning labels to segs, thus I propose to add this node to the impact pack.

![image](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/3026023/b4433f66-7efc-4038-8916-36e6656f90c5)

It gets funky when used in conjunction with the BLIP Analyze Image node from the WAS suite which is capable of answering questions like "Is it the image of a woman or a man?" quite precisely (it will return simply "woman" or "man") as I have found and it outperforms the gender classification models from HF. However, the BLIP node needs to be adapted for being able to provide a comma separated list, but it is not part of this repo so also not part of this PR. The assign labels node could be useful for other use cases as well I assume.

During working on this I also found two small bugs which are resolved as well in this PR.