### PR TITLE
ImageListToImageBatch: make the resize check optional (much faster for long vids)

### DIFF
--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -306,7 +306,7 @@ class ImageListToImageBatch:
     def INPUT_TYPES(s):
         return {"required": {
                         "images": ("IMAGE", ),
-                        "resize": ("BOOLEAN", {"default": True, "label_on": "when needed", "label_off": "never"}),
+                        "resize": ("BOOLEAN", {"default": True, "label_on": "when needed", "label_off": "never (faster)"}),
                       }
                 }
 

--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -306,6 +306,7 @@ class ImageListToImageBatch:
     def INPUT_TYPES(s):
         return {"required": {
                         "images": ("IMAGE", ),
+                        "resize": ("BOOLEAN", {"default": True, "label_on": "when needed", "label_off": "never"}),
                       }
                 }
 
@@ -316,9 +317,11 @@ class ImageListToImageBatch:
 
     CATEGORY = "ImpactPack/Operation"
 
-    def doit(self, images):
+    def doit(self, images, resize):
         if len(images) <= 1:
             return (images,)
+        elif not resize[0]:
+            return (torch.cat(images, dim=0),)
         else:
             image1 = images[0]
             for image2 in images[1:]:


### PR DESCRIPTION
When operating on a large batch size (eg 500) if the images are all the same size (eg a video), then the node ImageListToImageBatch takes much longer than necessary...

So this PR adds the option to skip the resize check and simply combine all of the images at once, which can be much faster from my testing (10 seconds vs 108 seconds with batch size 550, 512x512 res, tested on Colab T4).