### PR TITLE
node to create wildcard label prompt from string list

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -314,7 +314,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactConditionalStopIteration": ImpactConditionalStopIteration,
     "ImpactStringSelector": StringSelector,
     "StringListToString": StringListToString,
-    "WildcardPromptFromStringList": WildcardPromptFromStringList,
+    "WildcardPromptFromString": WildcardPromptFromString,
 
     "RemoveNoiseMask": RemoveNoiseMask,
 
@@ -436,7 +436,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ImpactMakeImageBatch": "Make Image Batch",
     "ImpactStringSelector": "String Selector",
     "StringListToString": "String List to String",
-    "WildcardPromptFromStringList": "Wildcard Prompt from String List",
+    "WildcardPromptFromString": "Wildcard Prompt from String",
     "ImpactIsNotEmptySEGS": "SEGS isn't Empty",
     "SetDefaultImageForSEGS": "Set Default Image for SEGS",
     "RemoveImageFromSEGS": "Remove Image from SEGS",

--- a/__init__.py
+++ b/__init__.py
@@ -313,6 +313,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactNeg": ImpactNeg,
     "ImpactConditionalStopIteration": ImpactConditionalStopIteration,
     "ImpactStringSelector": StringSelector,
+    "StringListToString": StringListToString,
     "WildcardPromptFromStringList": WildcardPromptFromStringList,
 
     "RemoveNoiseMask": RemoveNoiseMask,
@@ -434,6 +435,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ImpactMakeImageList": "Make Image List",
     "ImpactMakeImageBatch": "Make Image Batch",
     "ImpactStringSelector": "String Selector",
+    "StringListToString": "String List to String",
     "WildcardPromptFromStringList": "Wildcard Prompt from String List",
     "ImpactIsNotEmptySEGS": "SEGS isn't Empty",
     "SetDefaultImageForSEGS": "Set Default Image for SEGS",

--- a/__init__.py
+++ b/__init__.py
@@ -313,6 +313,7 @@ NODE_CLASS_MAPPINGS = {
     "ImpactNeg": ImpactNeg,
     "ImpactConditionalStopIteration": ImpactConditionalStopIteration,
     "ImpactStringSelector": StringSelector,
+    "WildcardPromptFromStringList": WildcardPromptFromStringList,
 
     "RemoveNoiseMask": RemoveNoiseMask,
 
@@ -433,6 +434,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ImpactMakeImageList": "Make Image List",
     "ImpactMakeImageBatch": "Make Image Batch",
     "ImpactStringSelector": "String Selector",
+    "WildcardPromptFromStringList": "Wildcard Prompt from String List",
     "ImpactIsNotEmptySEGS": "SEGS isn't Empty",
     "SetDefaultImageForSEGS": "Set Default Image for SEGS",
     "RemoveImageFromSEGS": "Remove Image from SEGS",

--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -514,7 +514,7 @@ class StringListToString:
         return (joined_text,)
 
 
-class WildcardPromptFromStringList:
+class WildcardPromptFromString:
     @classmethod
     def INPUT_TYPES(s):
         return {

--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -511,10 +511,10 @@ class WildcardPromptFromStringList:
     def doit(self, string_list, prefix_all, postfix_all, restrict_to_tags, exclude_tags):
         # need to access as list due to INPUT_IS_LIST
         # some sanity checks and normalization for later processing
-        if prefix_all[0] == None: prefix_all[0] = ""
-        if postfix_all[0] == None: postfix_all[0] = ""
-        if restrict_to_tags[0] == None: restrict_to_tags[0] = ""
-        if exclude_tags[0] == None: exclude_tags[0] = ""
+        if prefix_all[0] is None: prefix_all[0] = ""
+        if postfix_all[0] is None: postfix_all[0] = ""
+        if restrict_to_tags[0] is None: restrict_to_tags[0] = ""
+        if exclude_tags[0] is None: exclude_tags[0] = ""
         if not isinstance(restrict_to_tags[0], list):
             restrict_to_tags[0] = restrict_to_tags[0].split(", ")
         if not isinstance(exclude_tags[0], list):


### PR DESCRIPTION
The idea behind this node is to automatically create a wildcard prompt for the SEGS detailer. The purpose is to have a single prompt per tile/SEG which guides a denoising process for upscaling an image (in addition to the regular upscale prompt).

This strategy should help to either increase the denoising strength for added details or protect against hallucinations at the same denoise level.

The [WD14 tagger of pythongosssss](https://github.com/pythongosssss/ComfyUI-WD14-Tagger) works nicely for assigning tags on the fly for each tile. It is required to use that or something else to create the string list for the node input.

A prototype workflow is attached to this PR.

[prompt-per-tile-sample.json](https://github.com/ltdrdata/ComfyUI-Impact-Pack/files/14828491/prompt-per-tile-sample.json)
