### PR TITLE
Fix conditioning masks not being cropped in SEGSDetailer

### DIFF
--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -476,6 +476,17 @@ def crop_ndarray4(npimg, crop_region):
 crop_tensor4 = crop_ndarray4
 
 
+def crop_ndarray3(npimg, crop_region):
+    x1 = crop_region[0]
+    y1 = crop_region[1]
+    x2 = crop_region[2]
+    y2 = crop_region[3]
+
+    cropped = npimg[:, y1:y2, x1:x2]
+
+    return cropped
+
+
 def crop_ndarray2(npimg, crop_region):
     x1 = crop_region[0]
     y1 = crop_region[1]


### PR DESCRIPTION
Conditionings can have masks, but SEGSDetailer doesn't crop them. As a result the conditionings are applied to the wrong areas of the detail patch.

This has only been checked with SDXL - I'm not sure if the structure of conditionings or dimension of masks is reliable across other models. This problem might also apply to other Detailers, but I only use SEGSDetailer currently.
