### PR TITLE
Fix Picker (SEGS) mutating underlying mask

### DIFF
--- a/modules/impact/segs_nodes.py
+++ b/modules/impact/segs_nodes.py
@@ -1383,7 +1383,7 @@ class SEGSPicker:
             else:
                 cropped_image = empty_pil_tensor()
 
-            mask_array = seg.cropped_mask
+            mask_array = seg.cropped_mask.copy()
             mask_array[mask_array < 0.3] = 0.3
             mask_array = mask_array[None, ..., None]
             cropped_image = cropped_image * mask_array


### PR DESCRIPTION
Using a Picker causes the underlying mask to be mutated, resulting in inconsistent side-effects