### PR TITLE
Updated Wildcard.py to fix my previous pull request on Wildcard-Multi-Select-Quantifier.

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -198,7 +198,8 @@ def process(text, seed=None):
             keyword = match['keyword'].lower()
             quantifier = int(match['quantifier']) if match['quantifier'] else 1
             replacement = '__|__'.join([keyword,] * quantifier)
-            text = RE_WildCardQuantifier.sub(f"__{replacement}__", text)
+            RE_TEMP = re.compile(fr"(?P<quantifier>\d+)#__(?P<keyword>{keyword})__", re.IGNORECASE)
+            text = RE_TEMP.sub(f"__{replacement}__", text)
 
         # pass1: replace options
         pass1, is_replaced1 = replace_options(text)

--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -198,7 +198,8 @@ def process(text, seed=None):
             keyword = match['keyword'].lower()
             quantifier = int(match['quantifier']) if match['quantifier'] else 1
             replacement = '__|__'.join([keyword,] * quantifier)
-            RE_TEMP = re.compile(fr"(?P<quantifier>\d+)#__(?P<keyword>{keyword})__", re.IGNORECASE)
+            wilder_keyword = keyword.replace('*', '\*')
+            RE_TEMP = re.compile(fr"(?P<quantifier>\d+)#__(?P<keyword>{wilder_keyword})__", re.IGNORECASE)
             text = RE_TEMP.sub(f"__{replacement}__", text)
 
         # pass1: replace options


### PR DESCRIPTION
Previously this new functionality would replace all subsequent occurrences of a quantified wildcard with the 1st match's wildcard keyword, utterly destroying the identity of subsequent wildcards.

In fixing this issue, it also became apparent that using '\*' character in wildcards in combination with quantifier did not work well due to the re-compilation of the REGEX pattern now included a raw '\*' character that isn't properly escaped for the Pre-Impact quantifier feature's processing.

Now both issues are fixed.  I'm hoping there isn't more issues, but don't let me jinx myself.