### PR TITLE
Escape backslashes

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -170,7 +170,7 @@ def process(text, seed=None):
                 replacements_found = True
                 string = string.replace(f"__{match}__", replacement, 1)
             elif '*' in keyword:
-                subpattern = keyword.replace('*', '.*').replace('+','\+')
+                subpattern = keyword.replace('*', '.*').replace('+','\\+')
                 total_patterns = []
                 found = False
                 for k, v in local_wildcard_dict.items():
@@ -198,7 +198,7 @@ def process(text, seed=None):
             keyword = match['keyword'].lower()
             quantifier = int(match['quantifier']) if match['quantifier'] else 1
             replacement = '__|__'.join([keyword,] * quantifier)
-            wilder_keyword = keyword.replace('*', '\*')
+            wilder_keyword = keyword.replace('*', '\\*')
             RE_TEMP = re.compile(fr"(?P<quantifier>\d+)#__(?P<keyword>{wilder_keyword})__", re.IGNORECASE)
             text = RE_TEMP.sub(f"__{replacement}__", text)
 


### PR DESCRIPTION
`impact/wildcards.py`, getting a `SyntaxWarning: invalid escape sequence '\+'` (or `'\*'`, respectively) on Python 3.12. It does work (for now) without proper escaping, but future Python releases might break it. Hence it would make sense to escape them properly now before things go to hell later :)