### PR TITLE
fix: impact_sampling - missing UniPC sampler

### DIFF
--- a/modules/impact/impact_sampling.py
+++ b/modules/impact/impact_sampling.py
@@ -99,8 +99,13 @@ def ksampler(sampler_name, total_sigmas, extra_options={}, inpaint_options={}):
             return k_diffusion_sampling.sample_dpmpp_3m_sde_gpu(model, x, sigmas, **kwargs)
 
         sampler_function = sample_dpmpp_sde
+
     else:
-        if sampler_name == 'ddim':
+        if sampler_name == "uni_pc":
+            return samplers.KSAMPLER(samplers.uni_pc.sample_unipc)
+        elif sampler_name == "uni_pc_bh2":
+            return samplers.KSAMPLER(samplers.uni_pc.sample_unipc_bh2)
+        elif sampler_name == 'ddim':
             return samplers.ksampler("euler", inpaint_options={"random": True})
         else:
             return samplers.ksampler(sampler_name, extra_options, inpaint_options)


### PR DESCRIPTION
Closes #587. Thought I'd try to learn about Comfy inner workings. 

Images produce identical output and it seems to work fine with AYS and various Impact and Inspire KSampler nodes. 
Tried to follow the way and order they were called in comfy/samplers.py, to follow your addition of DDIM.
```python
# comfy/samplers.py
    if name == "uni_pc":
        sampler = KSAMPLER(uni_pc.sample_unipc)
    elif name == "uni_pc_bh2":
        sampler = KSAMPLER(uni_pc.sample_unipc_bh2)
    elif name == "ddim":
        sampler = ksampler("euler", inpaint_options={"random": True})
``` 


![image](https://github.com/ltdrdata/ComfyUI-Impact-Pack/assets/15876037/038b13ab-8b6d-4362-aed5-2445fe667383)
