### PR TITLE
Add spandrel to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ transformers
 opencv-python-headless
 GitPython
 scipy>=1.11.4
+spandrel


### PR DESCRIPTION
The module `spandrel` is required as part of `install.py`, and without it, the import of the custom nodes will fail.

Closes #638 