### PR TITLE
Fix: Wildcard Prompt from String node

### DIFF
--- a/modules/impact/segs_nodes.py
+++ b/modules/impact/segs_nodes.py
@@ -1530,7 +1530,7 @@ class MakeTileSEGS:
         return {"required": {
                      "images": ("IMAGE", ),
                      "bbox_size": ("INT", {"default": 512, "min": 64, "max": 4096, "step": 8}),
-                     "crop_factor": ("FLOAT", {"default": 3.0, "min": 1.0, "max": 10, "step": 0.1}),
+                     "crop_factor": ("FLOAT", {"default": 3.0, "min": 1.0, "max": 10, "step": 0.01}),
                      "min_overlap": ("INT", {"default": 5, "min": 0, "max": 512, "step": 1}),
                      "filter_segs_dilation": ("INT", {"default": 20, "min": -255, "max": 255, "step": 1}),
                      "mask_irregularity": ("FLOAT", {"default": 0, "min": 0, "max": 1.0, "step": 0.01}),

--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -564,10 +564,10 @@ class WildcardPromptFromString:
             labels.append(label)
             x = x.split(", ")
             # restrict to tags
-            if restrict_to_tags != "":
+            if restrict_to_tags != [""]:
                 x = list(set(x) & set(restrict_to_tags))
             # remove tags
-            if exclude_tags != "":
+            if exclude_tags != [""]:
                 x = list(set(x) - set(exclude_tags))
             # next row: <LABEL> <PREFIX> <TAGS> <POSTFIX>
             prompt_for_seg = f'[{label}] {prefix_all} {", ".join(x)} {postfix_all}'.strip()


### PR DESCRIPTION
Fix: when no exclude_tags or restrict_to_tags in a Wildcard Prompt from String node. They are empty lists by default. 


PS: Haven't tested an opposite case.