### PR TITLE
Fix input type on ImpactLogger

### DIFF
--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -196,7 +196,7 @@ class ImpactLogger:
     @classmethod
     def INPUT_TYPES(s):
         return {"required": {
-                        "data": (any_typ, ""),
+                        "data": (any_typ,),
                         "text": ("STRING", {"multiline": True}),
                     },
                 "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"},


### PR DESCRIPTION
The second item in the input spec tuple should be a dict.