### PR TITLE
Add custom_wildcards path fallback

### DIFF
--- a/modules/impact/config.py
+++ b/modules/impact/config.py
@@ -32,6 +32,10 @@ def read_config():
         config.read(config_path)
         default_conf = config['default']
 
+        if not os.path.exists(default_conf['custom_wildcards']):
+            print(f"[WARN] ComfyUI-Impact-Pack: custom_wildcards path not found: {default_conf['custom_wildcards']}. Using default path.")
+            default_conf['custom_wildcards'] = os.path.join(my_path, "..", "..", "custom_wildcards")
+
         return {
                     'dependency_version': int(default_conf['dependency_version']),
                     'mmdet_skip': default_conf['mmdet_skip'].lower() == 'true' if 'mmdet_skip' in default_conf else True,


### PR DESCRIPTION
Fallback to the `custom_wildcards` folder in the project root if the path in the config file doesn't exist.