### PR TITLE
Fix passing empty mask to SEGS controlnet preprocessors

### DIFF
--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -1773,7 +1773,8 @@ class IPAdapterWrapper:
 
 
 class ControlNetWrapper:
-    def __init__(self, control_net, strength, preprocessor, prev_control_net=None, original_size=None, crop_region=None, control_image=None):
+    def __init__(self, control_net, strength, preprocessor, prev_control_net=None, 
+                 original_size=None, crop_region=None, control_image=None, control_mask=None):
         self.control_net = control_net
         self.strength = strength
         self.preprocessor = preprocessor
@@ -1785,6 +1786,9 @@ class ControlNetWrapper:
         else:
             self.control_image = None
 
+        if control_mask is not None:
+            self.control_mask = torch.from_numpy(control_mask)
+
     def apply(self, positive, negative, image, mask=None, use_acn=False):
         cnet_image_list = []
         prev_cnet_images = []
@@ -1795,7 +1799,7 @@ class ControlNetWrapper:
         if self.control_image is not None:
             cnet_image = self.control_image
         elif self.preprocessor is not None:
-            cnet_image = self.preprocessor.apply(image, mask)
+            cnet_image = self.preprocessor.apply(image, self.control_mask)
         else:
             cnet_image = image
 
@@ -1825,7 +1829,7 @@ class ControlNetWrapper:
 
 class ControlNetAdvancedWrapper:
     def __init__(self, control_net, strength, start_percent, end_percent, preprocessor, prev_control_net=None,
-                 original_size=None, crop_region=None, control_image=None):
+                 original_size=None, crop_region=None, control_image=None, control_mask=None):
         self.control_net = control_net
         self.strength = strength
         self.preprocessor = preprocessor
@@ -1838,6 +1842,9 @@ class ControlNetAdvancedWrapper:
             self.control_image = torch.tensor(utils.tensor_crop(self.control_image, crop_region))
         else:
             self.control_image = None
+        
+        if control_mask is not None:
+            self.control_mask = torch.from_numpy(control_mask)
 
     def doit_ipadapter(self, model):
         if self.prev_control_net is not None:
@@ -1855,7 +1862,7 @@ class ControlNetAdvancedWrapper:
         if self.control_image is not None:
             cnet_image = self.control_image
         elif self.preprocessor is not None:
-            cnet_image = self.preprocessor.apply(image, mask)
+            cnet_image = self.preprocessor.apply(image, self.control_mask)
         else:
             cnet_image = image
 

--- a/modules/impact/segs_nodes.py
+++ b/modules/impact/segs_nodes.py
@@ -1370,7 +1370,7 @@ class ControlNetApplySEGS:
 
         for seg in segs[1]:
             control_net_wrapper = core.ControlNetWrapper(control_net, strength, segs_preprocessor, seg.control_net_wrapper,
-                                                         original_size=segs[0], crop_region=seg.crop_region, control_image=control_image)
+                                                         original_size=segs[0], crop_region=seg.crop_region, control_image=control_image, control_mask=seg.cropped_mask)
             new_seg = SEG(seg.cropped_image, seg.cropped_mask, seg.confidence, seg.crop_region, seg.bbox, seg.label, control_net_wrapper)
             new_segs.append(new_seg)
 
@@ -1405,7 +1405,7 @@ class ControlNetApplyAdvancedSEGS:
         for seg in segs[1]:
             control_net_wrapper = core.ControlNetAdvancedWrapper(control_net, strength, start_percent, end_percent, segs_preprocessor,
                                                                  seg.control_net_wrapper, original_size=segs[0], crop_region=seg.crop_region,
-                                                                 control_image=control_image)
+                                                                 control_image=control_image, control_mask=seg.cropped_mask)
             new_seg = SEG(seg.cropped_image, seg.cropped_mask, seg.confidence, seg.crop_region, seg.bbox, seg.label, control_net_wrapper)
             new_segs.append(new_seg)
 


### PR DESCRIPTION
Hi!

I encountered an issue when using xinsir's SDXL union controlnet for inpainting with SEGS.

There were two issues:
1. Wrong inpaint fill color for xinsir union controlnet.
[Fixed here](https://github.com/ltdrdata/ComfyUI-Inspire-Pack/pull/170)
2. Not passing cropped mask from SEGS to controlnet preprocessors, resulting in fully black filled controlnet image when using Inpaint Preprocessor Provider (SEGS).
**Fixed in this PR**.

Before:
![image](https://github.com/user-attachments/assets/8be8d941-1300-43f3-9800-9833be0cbd23)
After:
![image](https://github.com/user-attachments/assets/9d699fac-dcde-4ab0-8cc4-d68312de839c)

Be aware that this is a quick fix, and I have not had time to check every possible combination of controlnets and preprocesors.
Also my approach might be suboptimal, and I'm open to improvement suggestions.

Here's the test workflow:
[workflow (6).json](https://github.com/user-attachments/files/17194393/workflow.6.json)
