### PR TITLE
Prefer widget.callback over stack trace check

### DIFF
--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -587,17 +587,17 @@ app.registerExtension({
 		}
 
 		if(node.comfyClass == "ImpactSEGSLabelFilter" || node.comfyClass == "SEGSLabelFilterDetailerHookProvider") {
+			node.widgets[0].callback = (value, canvas, node, pos, e) => {
+				if(node.widgets[1].value.trim() != "" && !node.widgets[1].value.trim().endsWith(","))
+					node.widgets[1].value += ", "
+
+				node.widgets[1].value += value;
+				if(node.widgets_values)
+					node.widgets_values[1] = node.widgets[1].value;
+			}
+
 			Object.defineProperty(node.widgets[0], "value", {
 				set: (value) => {
-						const stackTrace = new Error().stack;
-						if(stackTrace.includes('inner_value_change')) {
-							if(node.widgets[1].value.trim() != "" && !node.widgets[1].value.trim().endsWith(","))
-								node.widgets[1].value += ", "
-
-							node.widgets[1].value += value;
-							node.widgets_values[1] = node.widgets[1].value;
-						}
-
 						node._value = value;
 					},
 				get: () => {
@@ -667,18 +667,15 @@ app.registerExtension({
 					break;
 			}
 
-			Object.defineProperty(node.widgets[combo_id+1], "value", {
-				set: (value) => {
-						const stackTrace = new Error().stack;
-						if(stackTrace.includes('inner_value_change')) {
-							if(value != "Select the Wildcard to add to the text") {
-								if(node.widgets[tbox_id].value != '')
-									node.widgets[tbox_id].value += ', '
+			node.widgets[combo_id+1].callback = (value, canvas, node, pos, e) => {
+				if(node.widgets[tbox_id].value != '')
+					node.widgets[tbox_id].value += ', '
 
-								node.widgets[tbox_id].value += value;
-							}
-						}
-					},
+				node.widgets[tbox_id].value += value;
+			}
+
+			Object.defineProperty(node.widgets[combo_id+1], "value", {
+				set: (value) => {},
 				get: () => { return "Select the Wildcard to add to the text"; }
 			});
 
@@ -689,24 +686,21 @@ app.registerExtension({
 				}
 			});
 
+			node.widgets[combo_id].callback = (value, canvas, node, pos, e) => {
+				let lora_name = value;
+				if (lora_name.endsWith('.safetensors')) {
+					lora_name = lora_name.slice(0, -12);
+				}
+
+				node.widgets[tbox_id].value += `<lora:${lora_name}>`;
+				if(node.widgets_values) {
+					node.widgets_values[tbox_id] = node.widgets[tbox_id].value;
+				}
+			}
+
 			if(has_lora) {
 				Object.defineProperty(node.widgets[combo_id], "value", {
 					set: (value) => {
-							const stackTrace = new Error().stack;
-							if(stackTrace.includes('inner_value_change')) {
-								if(value != "Select the LoRA to add to the text") {
-									let lora_name = value;
-									if (lora_name.endsWith('.safetensors')) {
-										lora_name = lora_name.slice(0, -12);
-									}
-
-									node.widgets[tbox_id].value += `<lora:${lora_name}>`;
-									if(node.widgets_values) {
-										node.widgets_values[tbox_id] = node.widgets[tbox_id].value;
-									}
-								}
-							}
-
 							node._value = value;
 						},
 

--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -688,7 +688,7 @@ app.registerExtension({
 
 			node.widgets[combo_id].callback = (value, canvas, node, pos, e) => {
 				let lora_name = value;
-				if (lora_name.endsWith('.safetensors')) {
+				if(lora_name.endsWith('.safetensors')) {
 					lora_name = lora_name.slice(0, -12);
 				}
 

--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -667,11 +667,18 @@ app.registerExtension({
 					break;
 			}
 
-			node.widgets[combo_id+1].callback = (value, canvas, node, pos, e) => {
-				if(node.widgets[tbox_id].value != '')
-					node.widgets[tbox_id].value += ', '
+			const { onWidgetChanged } = node
+			node.onWidgetChanged = function (widgetName, value, oldValue, widget) {
+				const result = onWidgetChanged?.apply(this, arguments)
 
-				node.widgets[tbox_id].value += value;
+				if (value != "Select the Wildcard to add to the text") {
+						if(node.widgets[tbox_id].value != '')
+						node.widgets[tbox_id].value += ', '
+
+					node.widgets[tbox_id].value += value;
+				}
+
+				return result
 			}
 
 			Object.defineProperty(node.widgets[combo_id+1], "value", {
@@ -686,22 +693,23 @@ app.registerExtension({
 				}
 			});
 
-			node.widgets[combo_id].callback = (value, canvas, node, pos, e) => {
-				let lora_name = value;
-				if(lora_name.endsWith('.safetensors')) {
-					lora_name = lora_name.slice(0, -12);
-				}
-
-				node.widgets[tbox_id].value += `<lora:${lora_name}>`;
-				if(node.widgets_values) {
-					node.widgets_values[tbox_id] = node.widgets[tbox_id].value;
-				}
-			}
-
 			if(has_lora) {
+				node.widgets[combo_id].callback = (value, canvas, node, pos, e) => {
+					let lora_name = node._value;
+					if(lora_name.endsWith('.safetensors')) {
+						lora_name = lora_name.slice(0, -12);
+					}
+
+					node.widgets[tbox_id].value += `<lora:${lora_name}>`;
+					if(node.widgets_values) {
+						node.widgets_values[tbox_id] = node.widgets[tbox_id].value;
+					}
+				}
+
 				Object.defineProperty(node.widgets[combo_id], "value", {
 					set: (value) => {
-							node._value = value;
+							if (value !== "Select the LoRA to add to the text")
+								node._value = value;
 						},
 
 					get: () => { return "Select the LoRA to add to the text"; }


### PR DESCRIPTION
Recent update to LiteGraph included a rename of a local function.  This value was being checked to limit calls to the widget value setter.

Behaviour has been replaced with widget `callback()`, which for combo boxes is always called (once!) when a value is clicked, regardless of any change.