### PR TITLE
feat: Add `upscaled` and `upscaled_refined` outputs to DetailerDebug nodes for more debugging capability

### DIFF
--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -318,11 +318,11 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     print(f"Detailer: segment upscale for ({bbox_w, bbox_h}) | crop region {w, h} x {upscale} -> {new_w, new_h}")
 
     # upscale
-    upscaled_unrefined_image = tensor_resize(image, new_w, new_h)
+    unrefined_upscaled_image = tensor_resize(image, new_w, new_h)
 
     cnet_pils = None
     if control_net_wrapper is not None:
-        positive, negative, cnet_pils = control_net_wrapper.apply(positive, negative, upscaled_unrefined_image, noise_mask)
+        positive, negative, cnet_pils = control_net_wrapper.apply(positive, negative, unrefined_upscaled_image, noise_mask)
         model, cnet_pils2 = control_net_wrapper.doit_ipadapter(model)
         cnet_pils.extend(cnet_pils2)
 
@@ -330,12 +330,12 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if noise_mask is not None and inpaint_model:
         imc_encode = nodes.InpaintModelConditioning().encode
         if 'noise_mask' in inspect.signature(imc_encode).parameters:
-            positive, negative, unrefined_upscaled_latent = imc_encode(positive, negative, upscaled_unrefined_image, vae, mask=noise_mask, noise_mask=True)
+            positive, negative, unrefined_upscaled_latent = imc_encode(positive, negative, unrefined_upscaled_image, vae, mask=noise_mask, noise_mask=True)
         else:
             print(f"[Impact Pack] ComfyUI is an outdated version.")
-            positive, negative, unrefined_upscaled_latent = imc_encode(positive, negative, upscaled_unrefined_image, vae, noise_mask)
+            positive, negative, unrefined_upscaled_latent = imc_encode(positive, negative, unrefined_upscaled_image, vae, noise_mask)
     else:
-        unrefined_upscaled_latent = to_latent_image(upscaled_unrefined_image, vae, vae_tiled_encode=vae_tiled_encode)
+        unrefined_upscaled_latent = to_latent_image(unrefined_upscaled_image, vae, vae_tiled_encode=vae_tiled_encode)
         if noise_mask is not None:
             unrefined_upscaled_latent['noise_mask'] = noise_mask
 
@@ -394,7 +394,7 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
 
     # don't convert to latent - latent break image
     # preserving pil is much better
-    return refined_image, cnet_pils, refined_upscaled_image
+    return refined_image, cnet_pils, refined_upscaled_image, unrefined_upscaled_image
 
 
 def enhance_detail_for_animatediff(image_frames, model, clip, vae, guide_size, guide_size_for_bbox, max_size, bbox, seed, steps, cfg,

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -318,11 +318,11 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     print(f"Detailer: segment upscale for ({bbox_w, bbox_h}) | crop region {w, h} x {upscale} -> {new_w, new_h}")
 
     # upscale
-    upscaled_image = tensor_resize(image, new_w, new_h)
+    upscaled_unrefined_image = tensor_resize(image, new_w, new_h)
 
     cnet_pils = None
     if control_net_wrapper is not None:
-        positive, negative, cnet_pils = control_net_wrapper.apply(positive, negative, upscaled_image, noise_mask)
+        positive, negative, cnet_pils = control_net_wrapper.apply(positive, negative, upscaled_unrefined_image, noise_mask)
         model, cnet_pils2 = control_net_wrapper.doit_ipadapter(model)
         cnet_pils.extend(cnet_pils2)
 
@@ -330,19 +330,19 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if noise_mask is not None and inpaint_model:
         imc_encode = nodes.InpaintModelConditioning().encode
         if 'noise_mask' in inspect.signature(imc_encode).parameters:
-            positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, vae, mask=noise_mask, noise_mask=True)
+            positive, negative, unrefined_upscaled_latent = imc_encode(positive, negative, upscaled_unrefined_image, vae, mask=noise_mask, noise_mask=True)
         else:
             print(f"[Impact Pack] ComfyUI is an outdated version.")
-            positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, vae, noise_mask)
+            positive, negative, unrefined_upscaled_latent = imc_encode(positive, negative, upscaled_unrefined_image, vae, noise_mask)
     else:
-        latent_image = to_latent_image(upscaled_image, vae, vae_tiled_encode=vae_tiled_encode)
+        unrefined_upscaled_latent = to_latent_image(upscaled_unrefined_image, vae, vae_tiled_encode=vae_tiled_encode)
         if noise_mask is not None:
-            latent_image['noise_mask'] = noise_mask
+            unrefined_upscaled_latent['noise_mask'] = noise_mask
 
     if detailer_hook is not None:
-        latent_image = detailer_hook.post_encode(latent_image)
+        unrefined_upscaled_latent = detailer_hook.post_encode(unrefined_upscaled_latent)
 
-    refined_latent = latent_image
+    refined_upscaled_latent = unrefined_upscaled_latent
 
     # ksampler
     for i in range(0, cycle):
@@ -350,51 +350,51 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
             if detailer_hook is not None:
                 detailer_hook.set_steps((i, cycle))
 
-            refined_latent = detailer_hook.cycle_latent(refined_latent)
+            refined_upscaled_latent = detailer_hook.cycle_latent(refined_upscaled_latent)
 
             model2, seed2, steps2, cfg2, sampler_name2, scheduler2, positive2, negative2, upscaled_latent2, denoise2 = \
-                detailer_hook.pre_ksample(model, seed+i, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise)
-            noise, is_touched = detailer_hook.get_custom_noise(seed+i, torch.zeros(latent_image['samples'].size()), is_touched=False)
+                detailer_hook.pre_ksample(model, seed+i, steps, cfg, sampler_name, scheduler, positive, negative, unrefined_upscaled_latent, denoise)
+            noise, is_touched = detailer_hook.get_custom_noise(seed+i, torch.zeros(unrefined_upscaled_latent['samples'].size()), is_touched=False)
             if not is_touched:
                 noise = None
         else:
             model2, seed2, steps2, cfg2, sampler_name2, scheduler2, positive2, negative2, upscaled_latent2, denoise2 = \
-                model, seed + i, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise
+                model, seed + i, steps, cfg, sampler_name, scheduler, positive, negative, unrefined_upscaled_latent, denoise
             noise = None
 
-        refined_latent = impact_sampling.ksampler_wrapper(model2, seed2, steps2, cfg2, sampler_name2, scheduler2, positive2, negative2,
-                                                          refined_latent, denoise2, refiner_ratio, refiner_model, refiner_clip, refiner_positive, refiner_negative,
+        refined_upscaled_latent = impact_sampling.ksampler_wrapper(model2, seed2, steps2, cfg2, sampler_name2, scheduler2, positive2, negative2,
+                                                          refined_upscaled_latent, denoise2, refiner_ratio, refiner_model, refiner_clip, refiner_positive, refiner_negative,
                                                           noise=noise, scheduler_func=scheduler_func)
 
     if detailer_hook is not None:
-        refined_latent = detailer_hook.pre_decode(refined_latent)
+        refined_upscaled_latent = detailer_hook.pre_decode(refined_upscaled_latent)
 
     # non-latent downscale - latent downscale cause bad quality
     start = time.time()
     if vae_tiled_decode:
-        (refined_image,) = nodes.VAEDecodeTiled().decode(vae, refined_latent, 512) # using default settings
+        (refined_upscaled_image,) = nodes.VAEDecodeTiled().decode(vae, refined_upscaled_latent, 512) # using default settings
         print(f"[Impact Pack] vae decoded (tiled) in {time.time() - start:.1f}s")
     else:
         try:
-            refined_image = vae.decode(refined_latent['samples'])
+            refined_upscaled_image = vae.decode(refined_upscaled_latent['samples'])
         except Exception as e:
             # usually an out-of-memory exception from the decode, so try a tiled approach
             print(f"[Impact Pack] failed after {time.time() - start:.1f}s, doing vae.decode_tiled 64...")
-            refined_image = vae.decode_tiled(refined_latent["samples"], tile_x=64, tile_y=64, )
+            refined_upscaled_image = vae.decode_tiled(refined_upscaled_latent["samples"], tile_x=64, tile_y=64, )
         print(f"[Impact Pack] vae decoded in {time.time() - start:.1f}s")
 
     if detailer_hook is not None:
-        refined_image = detailer_hook.post_decode(refined_image)
+        refined_upscaled_image = detailer_hook.post_decode(refined_upscaled_image)
 
     # downscale
-    refined_image = tensor_resize(refined_image, w, h)
+    refined_image = tensor_resize(refined_upscaled_image, w, h)
 
     # prevent mixing of device
     refined_image = refined_image.cpu()
 
     # don't convert to latent - latent break image
     # preserving pil is much better
-    return refined_image, cnet_pils
+    return refined_image, cnet_pils, refined_upscaled_image
 
 
 def enhance_detail_for_animatediff(image_frames, model, clip, vae, guide_size, guide_size_for_bbox, max_size, bbox, seed, steps, cfg,

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -251,6 +251,7 @@ class DetailerForEach:
         enhanced_alpha_list = []
         enhanced_list = []
         enhanced_upscaled_list = []
+        unenhanced_upscaled_list = []
         cropped_list = []
         cnet_pil_list = []
 
@@ -338,7 +339,7 @@ class DetailerForEach:
 
             orig_cropped_image = cropped_image.clone()
             if not (isinstance(model, str) and model == "DUMMY"):
-                enhanced_image, cnet_pils, enhanced_upscaled_image = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
+                enhanced_image, cnet_pils, enhanced_upscaled_image, unenhanced_upscaled_image = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
                                                                 seg.bbox, seg_seed, steps, cfg, sampler_name, scheduler,
                                                                 cropped_positive, cropped_negative, denoise, cropped_mask, force_inpaint,
                                                                 wildcard_opt=wildcard_item, wildcard_opt_concat_mode=wildcard_concat_mode,
@@ -358,6 +359,9 @@ class DetailerForEach:
 
             if enhanced_upscaled_image is not None:
                 enhanced_upscaled_list.append(enhanced_upscaled_image)
+
+            if unenhanced_upscaled_image is not None:
+                unenhanced_upscaled_list.append(unenhanced_upscaled_image)
 
             if not (enhanced_image is None):
                 # don't latent composite-> converting to latent caused poor quality
@@ -393,8 +397,9 @@ class DetailerForEach:
         enhanced_list.sort(key=lambda x: x.shape, reverse=True)
         enhanced_alpha_list.sort(key=lambda x: x.shape, reverse=True)
         enhanced_upscaled_list.sort(key=lambda x: x.shape, reverse=True)
+        unenhanced_upscaled_list.sort(key=lambda x: x.shape, reverse=True)
 
-        return image_tensor, cropped_list, enhanced_list, enhanced_alpha_list, cnet_pil_list, (segs[0], new_segs), enhanced_upscaled_list
+        return image_tensor, cropped_list, enhanced_list, enhanced_alpha_list, cnet_pil_list, (segs[0], new_segs), enhanced_upscaled_list, unenhanced_upscaled_list
 
     def doit(self, image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name,
              scheduler, positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard, cycle=1,
@@ -1580,7 +1585,7 @@ class MaskDetailerPipe:
 
 class DetailerForEachTest(DetailerForEach):
     RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE")
-    RETURN_NAMES = ("image", "cropped", "cropped_refined", "cropped_refined_alpha", "cnet_images", "upscaled_refined")
+    RETURN_NAMES = ("image", "cropped", "cropped_refined", "cropped_refined_alpha", "upscaled", "upscaled_refined", "cnet_images")
     OUTPUT_IS_LIST = (False, True, True, True, True, True)
 
     FUNCTION = "doit"
@@ -1594,7 +1599,7 @@ class DetailerForEachTest(DetailerForEach):
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
-        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs, upscaled_enhanced = \
+        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs, upscaled_enhanced, upscaled_unenhanced = \
             DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps,
                                       cfg, sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
@@ -1617,13 +1622,16 @@ class DetailerForEachTest(DetailerForEach):
         if len(cnet_pil_list) == 0:
             cnet_pil_list = [empty_pil_tensor()]
 
-        return enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, upscaled_enhanced
+        if len(upscaled_unenhanced) == 0:
+            upscaled_unenhanced = [empty_pil_tensor()]
+
+        return enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, upscaled_unenhanced, upscaled_enhanced, cnet_pil_list
 
 
 class DetailerForEachTestPipe(DetailerForEachPipe):
-    RETURN_TYPES = ("IMAGE", "SEGS", "BASIC_PIPE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE")
-    RETURN_NAMES = ("image", "segs", "basic_pipe", "cropped", "cropped_refined", "cropped_refined_alpha", 'cnet_images', 'upscaled_refined')
-    OUTPUT_IS_LIST = (False, False, False, True, True, True, True, True)
+    RETURN_TYPES = ("IMAGE", "SEGS", "BASIC_PIPE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE")
+    RETURN_NAMES = ("image", "segs", "basic_pipe", "cropped", "cropped_refined", "cropped_refined_alpha", 'upscaled', 'upscaled_refined','cnet_images', )
+    OUTPUT_IS_LIST = (False, False, False, True, True, True, True, True, True, True)
 
     FUNCTION = "doit"
 
@@ -1646,7 +1654,7 @@ class DetailerForEachTestPipe(DetailerForEachPipe):
         else:
             refiner_model, refiner_clip, _, refiner_positive, refiner_negative = refiner_basic_pipe_opt
 
-        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs, upscaled_enhanced = \
+        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs, upscaled_enhanced, upscaled_unenhanced = \
             DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg,
                                       sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
@@ -1669,10 +1677,13 @@ class DetailerForEachTestPipe(DetailerForEachPipe):
         if len(cnet_pil_list) == 0:
             cnet_pil_list = [empty_pil_tensor()]
 
-        if len(upscaled_refined) == 0:
-            upscaled_refined = [empty_pil_tensor()]
+        if len(upscaled_enhanced) == 0:
+            upscaled_enhanced = [empty_pil_tensor()]
 
-        return enhanced_img, new_segs, basic_pipe, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, upscaled_enhanced
+        if len(upscaled_unenhanced) == 0:   
+            upscaled_unenhanced = [empty_pil_tensor()]
+
+        return enhanced_img, new_segs, basic_pipe, cropped, cropped_enhanced, cropped_enhanced_alpha, upscaled_unenhanced, upscaled_enhanced, cnet_pil_list, 
 
 
 class SegsBitwiseAndMask:

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -250,6 +250,7 @@ class DetailerForEach:
         image = image.clone()
         enhanced_alpha_list = []
         enhanced_list = []
+        enhanced_upscaled_list = []
         cropped_list = []
         cnet_pil_list = []
 
@@ -337,7 +338,7 @@ class DetailerForEach:
 
             orig_cropped_image = cropped_image.clone()
             if not (isinstance(model, str) and model == "DUMMY"):
-                enhanced_image, cnet_pils = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
+                enhanced_image, cnet_pils, enhanced_upscaled_image = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
                                                                 seg.bbox, seg_seed, steps, cfg, sampler_name, scheduler,
                                                                 cropped_positive, cropped_negative, denoise, cropped_mask, force_inpaint,
                                                                 wildcard_opt=wildcard_item, wildcard_opt_concat_mode=wildcard_concat_mode,
@@ -354,6 +355,9 @@ class DetailerForEach:
 
             if cnet_pils is not None:
                 cnet_pil_list.extend(cnet_pils)
+
+            if enhanced_upscaled_image is not None:
+                enhanced_upscaled_list.append(enhanced_upscaled_image)
 
             if not (enhanced_image is None):
                 # don't latent composite-> converting to latent caused poor quality
@@ -388,8 +392,9 @@ class DetailerForEach:
         cropped_list.sort(key=lambda x: x.shape, reverse=True)
         enhanced_list.sort(key=lambda x: x.shape, reverse=True)
         enhanced_alpha_list.sort(key=lambda x: x.shape, reverse=True)
+        enhanced_upscaled_list.sort(key=lambda x: x.shape, reverse=True)
 
-        return image_tensor, cropped_list, enhanced_list, enhanced_alpha_list, cnet_pil_list, (segs[0], new_segs)
+        return image_tensor, cropped_list, enhanced_list, enhanced_alpha_list, cnet_pil_list, (segs[0], new_segs), enhanced_upscaled_list
 
     def doit(self, image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name,
              scheduler, positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard, cycle=1,
@@ -1574,9 +1579,9 @@ class MaskDetailerPipe:
 
 
 class DetailerForEachTest(DetailerForEach):
-    RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE")
-    RETURN_NAMES = ("image", "cropped", "cropped_refined", "cropped_refined_alpha", "cnet_images")
-    OUTPUT_IS_LIST = (False, True, True, True, True)
+    RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE")
+    RETURN_NAMES = ("image", "cropped", "cropped_refined", "cropped_refined_alpha", "cnet_images", "upscaled_refined")
+    OUTPUT_IS_LIST = (False, True, True, True, True, True)
 
     FUNCTION = "doit"
 
@@ -1589,7 +1594,7 @@ class DetailerForEachTest(DetailerForEach):
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
-        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs = \
+        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs, upscaled_enhanced = \
             DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps,
                                       cfg, sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
@@ -1606,16 +1611,19 @@ class DetailerForEachTest(DetailerForEach):
         if len(cropped_enhanced_alpha) == 0:
             cropped_enhanced_alpha = [empty_pil_tensor()]
 
+        if len(upscaled_enhanced) == 0:
+            upscaled_enhanced = [empty_pil_tensor()]
+
         if len(cnet_pil_list) == 0:
             cnet_pil_list = [empty_pil_tensor()]
 
-        return enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list
+        return enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, upscaled_enhanced
 
 
 class DetailerForEachTestPipe(DetailerForEachPipe):
-    RETURN_TYPES = ("IMAGE", "SEGS", "BASIC_PIPE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", )
-    RETURN_NAMES = ("image", "segs", "basic_pipe", "cropped", "cropped_refined", "cropped_refined_alpha", 'cnet_images')
-    OUTPUT_IS_LIST = (False, False, False, True, True, True, True)
+    RETURN_TYPES = ("IMAGE", "SEGS", "BASIC_PIPE", "IMAGE", "IMAGE", "IMAGE", "IMAGE", "IMAGE")
+    RETURN_NAMES = ("image", "segs", "basic_pipe", "cropped", "cropped_refined", "cropped_refined_alpha", 'cnet_images', 'upscaled_refined')
+    OUTPUT_IS_LIST = (False, False, False, True, True, True, True, True)
 
     FUNCTION = "doit"
 
@@ -1638,7 +1646,7 @@ class DetailerForEachTestPipe(DetailerForEachPipe):
         else:
             refiner_model, refiner_clip, _, refiner_positive, refiner_negative = refiner_basic_pipe_opt
 
-        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs = \
+        enhanced_img, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs, upscaled_enhanced = \
             DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg,
                                       sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
@@ -1661,7 +1669,10 @@ class DetailerForEachTestPipe(DetailerForEachPipe):
         if len(cnet_pil_list) == 0:
             cnet_pil_list = [empty_pil_tensor()]
 
-        return enhanced_img, new_segs, basic_pipe, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list
+        if len(upscaled_refined) == 0:
+            upscaled_refined = [empty_pil_tensor()]
+
+        return enhanced_img, new_segs, basic_pipe, cropped, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, upscaled_enhanced
 
 
 class SegsBitwiseAndMask:


### PR DESCRIPTION
This is just a placeholder for now. I still need to do more testing. It adds two extra outputs to the "DetailerDebug (SEGS)" and "DetailerDebug (SEGS/pipe)" nodes:

- `upscaled`
- `upscaled_refined`

These are similar to `cropped` and `cropped_refined` but they show the full upscaled image before and after it is refined at full resolution, and before it is downscaled to original size.

Example in use locally:

![image](https://github.com/user-attachments/assets/ee677beb-5a58-4f4f-b515-d486a89a838e)

In the example I intentionally used an unrealistically high denoise value, to demonstrate that that the face is being generated at high resolution under the hood (this is not very clear from the documentation, and there was no way to see what was going on under the hood at high resolution)
