### PR TITLE
feat: tensor_paste supports RGBA images with alpha channel blending

### DIFF
--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -178,31 +178,71 @@ def tensor2numpy(image):
 
 
 def tensor_paste(image1, image2, left_top, mask):
-    """Mask and image2 has to be the same size"""
+    """
+    Pastes image2 onto image1 at position left_top using mask.
+    Supports both RGB and RGBA images.
+    """
     _tensor_check_image(image1)
     _tensor_check_image(image2)
     _tensor_check_mask(mask)
+    
     if image2.shape[1:3] != mask.shape[1:3]:
         mask = resize_mask(mask.squeeze(dim=3), image2.shape[1:3]).unsqueeze(dim=3)
-        # raise ValueError(f"Inconsistent size: Image ({image2.shape[1:3]}) != Mask ({mask.shape[1:3]})")
-
+    
     x, y = left_top
-    _, h1, w1, _ = image1.shape
-    _, h2, w2, _ = image2.shape
-
-    # calculate image patch size
+    _, h1, w1, c1 = image1.shape
+    _, h2, w2, c2 = image2.shape
+    
+    # Calculate image patch size
     w = min(w1, x + w2) - x
     h = min(h1, y + h2) - y
-
+    
     # If the patch is out of bound, nothing to do!
     if w <= 0 or h <= 0:
         return
-
+    
     mask = mask[:, :h, :w, :]
-    image1[:, y:y+h, x:x+w, :] = (
-        (1 - mask) * image1[:, y:y+h, x:x+w, :] +
-        mask * image2[:, :h, :w, :]
-    )
+    
+    # Get the region to be modified
+    region1 = image1[:, y:y+h, x:x+w, :]
+    region2 = image2[:, :h, :w, :]
+    
+    # Handle RGB and RGBA cases
+    if c1 == 3 and c2 == 3:
+        # Both RGB - simple case
+        image1[:, y:y+h, x:x+w, :] = (1 - mask) * region1 + mask * region2
+    
+    elif c1 == 4 and c2 == 4:
+        # Both RGBA - need to handle alpha channel separately
+        # RGB channels
+        image1[:, y:y+h, x:x+w, :3] = (
+            (1 - mask) * region1[:, :, :, :3] +
+            mask * region2[:, :, :, :3]
+        )
+        
+        # Alpha channel - use "over" composition
+        a1 = region1[:, :, :, 3:4]
+        a2 = region2[:, :, :, 3:4] * mask
+        new_alpha = a1 + a2 * (1 - a1)
+        image1[:, y:y+h, x:x+w, 3:4] = new_alpha
+    
+    elif c1 == 4 and c2 == 3:
+        # Target is RGBA, source is RGB - assume source is fully opaque
+        image1[:, y:y+h, x:x+w, :3] = (
+            (1 - mask) * region1[:, :, :, :3] +
+            mask * region2
+        )
+        # Alpha channel - reduce alpha where mask is applied
+        image1[:, y:y+h, x:x+w, 3:4] = region1[:, :, :, 3:4] * (1 - mask) + mask
+    
+    elif c1 == 3 and c2 == 4:
+        # Target is RGB, source is RGBA - apply source alpha to mask
+        effective_mask = mask * region2[:, :, :, 3:4]
+        image1[:, y:y+h, x:x+w, :] = (
+            (1 - effective_mask) * region1 +
+            effective_mask * region2[:, :, :, :3]
+        )
+    
     return
 
 


### PR DESCRIPTION
This enhancement adds support for properly handling RGBA images in the tensor_paste function.

The previous implementation caused errors when pasting images with alpha channels. Now the function can handle all combinations of RGB and RGBA images:
- RGB to RGB (unchanged)
- RGBA to RGBA (with proper alpha compositing)
- RGB to RGBA
- RGBA to RGB

Fix for the error: "RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 3"