### PR TITLE
change wildcard {} regex to allow escaping

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -219,7 +219,7 @@ def process(text, seed=None):
             replacements_found = True
             return replacement
 
-        pattern = r'{([^{}]*?)}'
+        pattern = r'(?<!\\)\{((?:[^{}]|(?<=\\)[{}])*?)(?<!\\)\}'
         replaced_string = re.sub(pattern, replace_option, string)
 
         return replaced_string, replacements_found


### PR DESCRIPTION
I need this to allow for keeping the non wildcard {} used for Jinja2 templating (with the dynamic prompts nodes)
no idea if itl be useful for anyone else figured ide PR is anyways