### PR TITLE
Fix empty widgets array prevents node delete

### DIFF
--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -509,7 +509,7 @@ app.registerExtension({
 			nodeType.prototype.onConnectionsChange = function (type, index, connected, link_info) {
 				const stackTrace = new Error().stack;
 				if(stackTrace.includes('loadGraphData')) {
-					if(this.widgets) {
+					if(this.widgets?.[0]) {
 						this.widgets[0].options.max = this.inputs.length-3;
 						this.widgets[0].value = Math.min(this.widgets[0].value, this.widgets[0].options.max);
 					}
@@ -606,7 +606,7 @@ app.registerExtension({
 					this.addInput(`${input_name}${slot_i}`, this.outputs[0].type);
 				}
 
-				if(this.widgets) {
+				if(this.widgets?.[0]) {
 					this.widgets[0].options.max = this.inputs.length-3;
 					this.widgets[0].value = Math.min(this.widgets[0].value, this.widgets[0].options.max);
 				}


### PR DESCRIPTION
- Adds optional chaining check.

If the node `widgets` array is present but contains no items, `this.widgets[0]` is undefined.  This throws when attempting to access the `options` property.

This is preventing some Impact-Pack nodes from being deleted.  It's not caught or handled by frontend, interrupting the delete partway through.  With a few other factors, it may result in a corrupt workflow.