### PR TITLE
Fix: PreviewBridge mask editor KeyError with clipspace files + restore fresh image behavior

### DIFF
--- a/modules/impact/bridge_nodes.py
+++ b/modules/impact/bridge_nodes.py
@@ -132,7 +132,8 @@ class PreviewBridge:
 
         # If images changed, clear the mask cache to ensure fresh start behavior
         # This restores the original behavior where new images start with empty masks
-        if images_changed and unique_id in core.preview_bridge_last_mask_cache:
+        # unless restore_mask is set to "always" or "if_same_size"
+        if images_changed and restore_mask not in ["always", "if_same_size"] and unique_id in core.preview_bridge_last_mask_cache:
             del core.preview_bridge_last_mask_cache[unique_id]
 
         # Handle clipspace files that aren't registered in the preview bridge system
@@ -152,10 +153,16 @@ class PreviewBridge:
         else:
             # For new images (images_changed=True), we want to start fresh regardless of restore_mask
             # For same image with refresh needed, respect the restore_mask setting
-            if restore_mask != "never" and not images_changed:
+            # Exception: when restore_mask is "always", restore even with new images
+            # Exception: when restore_mask is "if_same_size", allow restoration to check size compatibility
+            if restore_mask != "never" and (not images_changed or restore_mask in ["always", "if_same_size"]):
                 mask = core.preview_bridge_last_mask_cache.get(unique_id)
-                if mask is None or (restore_mask != "always" and mask.shape[1:] != images.shape[1:3]):
+                if mask is None:
                     mask = None
+                elif restore_mask == "if_same_size" and mask.shape[1:] != images.shape[1:3]:
+                    # For if_same_size, clear mask if dimensions don't match
+                    mask = None
+                # For "always", keep the mask regardless of size
             else:
                 mask = None
 
@@ -368,7 +375,8 @@ class PreviewBridgeLatent:
             latent_changed = True
 
         # If latent changed, clear the mask cache to ensure fresh start behavior
-        if latent_changed and unique_id in core.preview_bridge_last_mask_cache:
+        # unless restore_mask is set to "always" or "if_same_size"
+        if latent_changed and restore_mask not in ["always", "if_same_size"] and unique_id in core.preview_bridge_last_mask_cache:
             del core.preview_bridge_last_mask_cache[unique_id]
 
         # Handle clipspace files that aren't registered in the preview bridge system
@@ -425,10 +433,16 @@ class PreviewBridgeLatent:
             else:
                 # For new latents (latent_changed=True), start fresh regardless of restore_mask
                 # For same latent with refresh needed, respect the restore_mask setting
-                if restore_mask != "never" and not latent_changed:
+                # Exception: when restore_mask is "always", restore even with new latents
+                # Exception: when restore_mask is "if_same_size", allow restoration to check size compatibility
+                if restore_mask != "never" and (not latent_changed or restore_mask in ["always", "if_same_size"]):
                     mask = core.preview_bridge_last_mask_cache.get(unique_id)
-                    if mask is None or (restore_mask != "always" and mask.shape[1:] != decoded_image.shape[1:3]):
+                    if mask is None:
                         mask = None
+                    elif restore_mask == "if_same_size" and mask.shape[1:] != decoded_image.shape[1:3]:
+                        # For if_same_size, clear mask if dimensions don't match
+                        mask = None
+                    # For "always", keep the mask regardless of size
                 else:
                     mask = None
 

--- a/modules/impact/bridge_nodes.py
+++ b/modules/impact/bridge_nodes.py
@@ -48,10 +48,10 @@ class PreviewBridge:
         if pb_id not in core.preview_bridge_image_id_map:
             is_fail = True
 
-        image_path, ui_item = core.preview_bridge_image_id_map[pb_id]
-
-        if not os.path.isfile(image_path):
-            is_fail = True
+        if not is_fail:
+            image_path, ui_item = core.preview_bridge_image_id_map[pb_id]
+            if not os.path.isfile(image_path):
+                is_fail = True
 
         if not is_fail:
             i = Image.open(image_path)
@@ -76,20 +76,83 @@ class PreviewBridge:
 
         return image, mask.unsqueeze(0), ui_item
 
+    @staticmethod
+    def register_clipspace_image(clipspace_path, node_id):
+        """Register a clipspace image file in the preview bridge system.
+        
+        This handles the case where ComfyUI's mask editor creates clipspace files
+        that need to be integrated with the preview bridge system.
+        """
+        # Remove [input] suffix if present
+        clean_path = clipspace_path.replace(" [input]", "").replace("[input]", "")
+        
+        # Try to find the actual clipspace file
+        input_dir = folder_paths.get_input_directory()
+        potential_paths = [
+            clean_path,
+            os.path.join(input_dir, clean_path),
+            os.path.join(input_dir, "clipspace", os.path.basename(clean_path)),
+            os.path.abspath(clean_path),
+        ]
+        
+        actual_file = None
+        for path in potential_paths:
+            if os.path.isfile(path):
+                actual_file = path
+                break
+        
+        if not actual_file:
+            return False
+            
+        # Create ui_item for the clipspace file
+        ui_item = {
+            'filename': os.path.basename(actual_file),
+            'subfolder': 'clipspace',
+            'type': 'input'
+        }
+        
+        # Register it using the preview bridge system
+        core.set_previewbridge_image(node_id, actual_file, ui_item)
+        # Also register under the original clipspace path for compatibility
+        core.preview_bridge_image_id_map[clipspace_path] = (actual_file, ui_item)
+        
+        return True
+
     def doit(self, images, image, unique_id, block=False, restore_mask="never", prompt=None, extra_pnginfo=None):
         need_refresh = False
+        images_changed = False
 
+        # Check if images have changed (this determines if we start fresh)
         if unique_id not in core.preview_bridge_cache:
             need_refresh = True
-
+            images_changed = True
         elif core.preview_bridge_cache[unique_id][0] is not images:
             need_refresh = True
+            images_changed = True
+
+        # If images changed, clear the mask cache to ensure fresh start behavior
+        # This restores the original behavior where new images start with empty masks
+        if images_changed and unique_id in core.preview_bridge_last_mask_cache:
+            del core.preview_bridge_last_mask_cache[unique_id]
+
+        # Handle clipspace files that aren't registered in the preview bridge system
+        # This only applies when images haven't changed (same image, new mask scenario)
+        if not need_refresh and image not in core.preview_bridge_image_id_map:
+            # Check if this is a clipspace file that needs to be registered
+            is_clipspace = image and ("clipspace" in image.lower() or "[input]" in image)
+            if is_clipspace:
+                if not PreviewBridge.register_clipspace_image(image, unique_id):
+                    need_refresh = True
+            else:
+                need_refresh = True
 
         if not need_refresh:
             pixels, mask, path_item = PreviewBridge.load_image(image)
             image = [path_item]
         else:
-            if restore_mask != "never":
+            # For new images (images_changed=True), we want to start fresh regardless of restore_mask
+            # For same image with refresh needed, respect the restore_mask setting
+            if restore_mask != "never" and not images_changed:
                 mask = core.preview_bridge_last_mask_cache.get(unique_id)
                 if mask is None or (restore_mask != "always" and mask.shape[1:] != images.shape[1:3]):
                     mask = None
@@ -248,10 +311,10 @@ class PreviewBridgeLatent:
         if pb_id not in core.preview_bridge_image_id_map:
             is_fail = True
 
-        image_path, ui_item = core.preview_bridge_image_id_map[pb_id]
-
-        if not os.path.isfile(image_path):
-            is_fail = True
+        if not is_fail:
+            image_path, ui_item = core.preview_bridge_image_id_map[pb_id]
+            if not os.path.isfile(image_path):
+                is_fail = True
 
         if not is_fail:
             i = Image.open(image_path)
@@ -291,15 +354,32 @@ class PreviewBridgeLatent:
             raise Exception("The version of latent is not compatible with preview_method.<BR>SD3, SD1/SD2, SDXL, SC-Prior, SC-B and FLUX.1 are not compatible with each other.")
 
         need_refresh = False
+        latent_changed = False
 
+        # Check if latent has changed
         if unique_id not in core.preview_bridge_cache:
             need_refresh = True
-
+            latent_changed = True
         elif (core.preview_bridge_cache[unique_id][0] is not latent
               or (vae_opt is None and core.preview_bridge_cache[unique_id][2] is not None)
               or (vae_opt is None and core.preview_bridge_cache[unique_id][1] != preview_method)
               or (vae_opt is not None and core.preview_bridge_cache[unique_id][2] is not vae_opt)):
             need_refresh = True
+            latent_changed = True
+
+        # If latent changed, clear the mask cache to ensure fresh start behavior
+        if latent_changed and unique_id in core.preview_bridge_last_mask_cache:
+            del core.preview_bridge_last_mask_cache[unique_id]
+
+        # Handle clipspace files that aren't registered in the preview bridge system
+        # This only applies when latent hasn't changed (same latent, new mask scenario)
+        if not need_refresh and image not in core.preview_bridge_image_id_map:
+            is_clipspace = image and ("clipspace" in image.lower() or "[input]" in image)
+            if is_clipspace:
+                if not PreviewBridge.register_clipspace_image(image, unique_id):
+                    need_refresh = True
+            else:
+                need_refresh = True
 
         if not need_refresh:
             pixels, mask, path_item = PreviewBridge.load_image(image)
@@ -343,7 +423,9 @@ class PreviewBridgeLatent:
 
                 is_empty_mask = False
             else:
-                if restore_mask != "never":
+                # For new latents (latent_changed=True), start fresh regardless of restore_mask
+                # For same latent with refresh needed, respect the restore_mask setting
+                if restore_mask != "never" and not latent_changed:
                     mask = core.preview_bridge_last_mask_cache.get(unique_id)
                     if mask is None or (restore_mask != "always" and mask.shape[1:] != decoded_image.shape[1:3]):
                         mask = None


### PR DESCRIPTION
On Windows 11 when using the PreviewBridge node's mask editor (accessed via right-click → "Open in Mask Editor"), two issues occurred in the latest ComfyUI build [v0.3.38](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.38) (commit [e6609dacdeeafa371fe4e9f303016a605a333a76](https://github.com/comfyanonymous/ComfyUI/commit/e6609dacdeeafa371fe4e9f303016a605a333a76)):

### Issue 1: Clipspace KeyError
1. Create and save a mask in the mask editor
2. First save works correctly 
3. Create and save a second mask → **KeyError** or **FileNotFoundError**
4. Subsequent mask edits would fail with errors like:
   ```
   KeyError: 'clipspace/clipspace-mask-1125217.3.png [input]'
   ```
### Issue 2: Lost "Fresh Start" Behavior  
5. After initial fix, new image generations would retain previous masks instead of starting with empty masks
6. But to maintain original behavior, expected new images to require creating new masks

## Reason for the new issues (from what I can gather) ...

### Clipspace Issue
The clipspace issue occurs due to a mismatch between ComfyUI's clipspace system and the Impact Pack's preview bridge system:

1. **Mask Editor Integration**: ComfyUI's mask editor creates files in the clipspace system with names like `clipspace-mask-12345.png [input]`
2. **Preview Bridge Expectation**: Impact Pack expects preview IDs like `$274-1748423590.3098016` 
3. **Frontend Conversion**: The JavaScript in `impact-image-util.js` is supposed to convert clipspace filenames to preview IDs via the `/impact/set/pb_id_image` API
4. **Timing Issue**: There's a race condition where the backend receives the clipspace filename before the frontend conversion completes

### Fresh Start Issue
The original code relied on cache invalidation to clear masks when images changed. My initial clipspace fix inadvertently made the cache more persistent, breaking the "fresh start" behavior where new images should begin with empty masks.

## Technical Details
The frontend JavaScript (`impact-image-util.js`) handles this conversion:
```javascript
Object.defineProperty(w, 'value', {
    async set(v) {
        if(v && v.constructor == String && v.startsWith('$')) {
            // from node feedback - uses preview ID system
        } else {
            // from clipspace - converts to preview ID  
            w._value = await loadImageFromUrl(image, node.id, v, false);
        }
    }
})
```

However, due to async timing, the backend sometimes receives the original clipspace filename instead of the converted preview ID.

## Solution

### Part 1: Clipspace Registration
Added a `register_clipspace_image()` method that:

1. **Detects clipspace files** by checking for "clipspace" or "[input]" in the filename
2. **Locates the actual file** by trying common clipspace paths
3. **Registers the file** in the preview bridge system using `core.set_previewbridge_image()`
4. **Creates dual registration** under both the preview ID and original clipspace path for compatibility

### Part 2: Fresh Start Behavior Restoration
Added explicit mask cache management:

1. **Track input changes** with `images_changed`/`latent_changed` flags
2. **Clear mask cache on change** by deleting `core.preview_bridge_last_mask_cache[unique_id]` when inputs change
3. **Preserve clipspace functionality** by only attempting clipspace registration when inputs haven't changed
4. **Respect restore_mask appropriately** - only for unchanged inputs, new inputs always start fresh

## Changes Made
- Added `register_clipspace_image()` static method to `PreviewBridge` class
- Added clipspace file detection logic in both `PreviewBridge.doit()` and `PreviewBridgeLatent.doit()`
- Enhanced cache validation to handle unregistered image parameters
- Added explicit mask cache clearing when images/latents change
- Modified restore_mask logic to respect "fresh start" behavior for new content
- Added safety check in `load_image()` to prevent KeyError when path lookup fails

## Behavior Matrix

| Scenario | Input Changed | Mask Cache | Result |
|----------|---------------|------------|---------|
| New generation | Yes | Cleared | Fresh mask (original behavior restored) |
| Same image, new clipspace mask | No | Preserved | Clipspace registration works |
| Same image, restore_mask="always" | No | Preserved | Mask restored as expected |
| Same image, restore_mask="never" | No | Preserved | Fresh mask |

## Did a few tests involving:
- First mask creation and save works
- Second mask creation and save works  
- Subsequent mask edits work without errors
- New image generations start with fresh/empty masks (original behavior)
- restore_mask settings work correctly for unchanged images
- Normal preview bridge functionality unchanged
- Backwards compatibility maintained

## Backwards Compatibility
This fix should theoretically be fully backwards compatible:
- No breaking changes to existing API
- Normal preview bridge workflow unchanged
- Only adds handling for the previously broken clipspace scenario
- Restores expected behavior for new image generations

## Things to consider...
For long-term stability, consider:

1. **Frontend Timing**: The async conversion in `impact-image-util.js` could be made more robust with proper promise chaining
2. **Unified System**: Eventually migrating to a single preview ID system throughout might eliminate this entire category of issues
3. **ComfyUI API Changes**: Not sure the best way to monitor ComfyUI updates that might affect clipspace/preview bridge interaction, but perhaps some sort of CI/CD?

This fix should theoretically address the immediate clipspace issue and the behavioral regression while maintaining full compatibility with existing workflows.