### PR TITLE
Fixing js files app.js import in case Comfy is served behind a url-prfixing proxy

### DIFF
--- a/js/mask-rect-area-advanced.js
+++ b/js/mask-rect-area-advanced.js
@@ -1,4 +1,4 @@
-import { app } from "/scripts/app.js";
+import { app } from "../../scripts/app.js";
 function showPreviewCanvas(node, app) {
 
     const widget = {

--- a/js/mask-rect-area.js
+++ b/js/mask-rect-area.js
@@ -1,4 +1,4 @@
-import { app } from "/scripts/app.js";
+import { app } from "../../scripts/app.js";
 function showPreviewCanvas(node, app) {
 
     const widget = {


### PR DESCRIPTION
Hello

I serve comfy behind a proxy at home and some files app.js import fail because they use absolute path.
Also I noticed this relative path is used in other files so I think unifying them would be great.

tell me if you see any issue with this MR.

Cheers