### PR TITLE
Use a generic input value finder for wildcard populate seed input

### DIFF
--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -476,6 +476,25 @@ def regional_sampler_seed_update(json_data):
                 PromptServer.instance.send_sync("impact-node-feedback", {"node_id": k, "widget_name": "seed_2nd", "type": "INT", "value": new_seed})
 
 
+def find_input_value(input_node, prompt, input_type=int, input_keys=('value',)):
+    input_val = None
+
+    try:
+        for n in input_keys:
+            input_val = input_node['inputs'].get(n, None)
+            if isinstance(input_val, input_type):
+                break
+            elif isinstance(input_val, list) and len(input_val):
+                input_val = find_input_value(prompt[input_val[0]], prompt=prompt, input_type=input_type, input_keys=input_keys)
+                if input_val is not None:
+                    break
+        
+    except Exception as e :
+        logging.warning(f"[Impact Pack] Error encountered on find {input_type} value - {e}")
+    
+    return input_val
+
+
 def onprompt_populate_wildcards(json_data):
     prompt = json_data['prompt']
 
@@ -501,13 +520,15 @@ def onprompt_populate_wildcards(json_data):
                             input_seed = int(input_node['inputs']['value'])
                             if not isinstance(input_seed, int):
                                 continue
-                        if input_node['class_type'] == 'Seed (rgthree)':
+                        elif input_node['class_type'] == 'Seed (rgthree)':
                             input_seed = int(input_node['inputs']['seed'])
                             if not isinstance(input_seed, int):
                                 continue
                         else:
-                            logging.info(f"[Impact Pack] Only `ImpactInt`, `Seed (rgthree)` and `Primitive` Node are allowed as the seed for '{v['class_type']}'. It will be ignored. ")
-                            continue
+                            input_seed = find_input_value(input_node, prompt=prompt, input_type=int, input_keys=('int', 'seed', 'value'))
+                            if input_seed is None:
+                                logging.info(f"[Impact Pack] Only `ImpactInt`, `Seed (rgthree)` and `Primitive` Node are allowed as the seed for '{v['class_type']}'. It will be ignored. ")
+                                continue
                     except Exception:
                         continue
                 else:


### PR DESCRIPTION
I added a generic value finder method to be used to look for seed value when populating the prompt using wildcards.

The code is only called if no `primitive`, `ImpactInt`, or `Seed (rgthree)` is found as input. It then tries to find a compatible input by parsing the input nodes (and eventually their parents) to look for a `'int'`, `'seed'`, or `'value'` input valueof `int` type.

This allow greater compatibility with most of the integer constant and seed nodes out there. In particular I use it to use a [custom workflow](https://docs.interstice.cloud/custom-graph/) in [krita-ai-diffusion](https://github.com/Acly/krita-ai-diffusion), so I can use wildcards when prompting in Krita. It also works with GetNode/SetNode from [KJNodes](https://github.com/kijai/ComfyUI-KJNodes).

Note : It does not work with math operations nodes as seed input.