### PR TITLE
Refactor model application in impact_pack.py

### DIFF
--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -301,7 +301,8 @@ class DetailerForEach:
             ordered_segs = segs[1]
 
         if not (isinstance(model, str) and model == "DUMMY") and noise_mask_feather > 0 and 'denoise_mask_function' not in model.model_options:
-            model = nodes_differential_diffusion.DifferentialDiffusion().apply(model)[0]
+            result = nodes_differential_diffusion.DifferentialDiffusion.execute(model, 1.0)
+            model = result.model if hasattr(result, 'model') else result[0]
 
         for i, seg in enumerate(ordered_segs):
             cropped_image = utils.crop_ndarray4(image.cpu().numpy(), seg.crop_region)  # Never use seg.cropped_image to handle overlapping area


### PR DESCRIPTION
## Problem

The Impact Pack was failing with the following error when using DifferentialDiffusion:

This occurred because ComfyUI updated the DifferentialDiffusion node to use the new ComfyAPI format, which returns  io.NodeOutput  objects instead of simple tuples.

## Solution

-   Updated the Impact Pack's  `do_detail`  method to properly handle the new  NodeOutput  format


## Changes

-   Modified  `modules/impact/impact_pack.py`  lines 304-306 in the  `DetailerForEach.do_detail`  method


## Testing

-   Tested with ComfyUI using new DifferentialDiffusion format


----------

**Files Changed:**

-   `modules/impact/impact_pack.py`

line 304 should be: 
```
            result = nodes_differential_diffusion.DifferentialDiffusion.execute(model, 1.0)
            model = result.model if hasattr(result, 'model') else result[0]`
```