### PR TITLE
Update util_nodes.py: Fix Reactor Masking Helper tensor device and shape mismatches

### DIFF
--- a/modules/impact/util_nodes.py
+++ b/modules/impact/util_nodes.py
@@ -375,15 +375,50 @@ class ImageListToImageBatch:
     CATEGORY = "ImpactPack/Operation"
 
     def doit(self, images):
-        if len(images) <= 1:
-            return (images[0],)
-        else:
-            image1 = images[0]
-            for image2 in images[1:]:
-                if image1.shape[1:] != image2.shape[1:]:
-                    image2 = comfy.utils.common_upscale(image2.movedim(-1, 1), image1.shape[2], image1.shape[1], "lanczos", "center").movedim(1, -1)
-                image1 = torch.cat((image1, image2), dim=0)
-            return (image1,)
+        if len(images) == 0:
+            return ()
+        if len(images) == 1:
+            img = images[0]
+            if img.ndim == 3:  # add batch dim if missing
+                img = img.unsqueeze(0)
+            return (img,)
+
+        # Start with the first image
+        image1 = images[0]
+        if image1.ndim == 3:
+            image1 = image1.unsqueeze(0)
+
+        for image2 in images[1:]:
+            # Ensure batch dim
+            if image2.ndim == 3:
+                image2 = image2.unsqueeze(0)
+
+            # Ensure same device
+            if image2.device != image1.device:
+                image2 = image2.to(image1.device)
+
+            # Ensure HxW match exactly
+            H, W = image1.shape[1], image1.shape[2]
+            if image2.shape[1] != H or image2.shape[2] != W:
+                image2 = comfy.utils.common_upscale(
+                    image2.movedim(-1, 1),  # move channels first
+                    W,  # width
+                    H,  # height
+                    "lanczos",
+                    "center"
+                ).movedim(1, -1)  # move channels back last
+
+            # Ensure channels match
+            if image2.shape[3] != image1.shape[3]:
+                # simple fix: truncate or pad channels
+                min_C = min(image1.shape[3], image2.shape[3])
+                image1 = image1[:, :, :, :min_C]
+                image2 = image2[:, :, :, :min_C]
+
+            # Concatenate along batch dimension
+            image1 = torch.cat((image1, image2), dim=0)
+
+        return (image1,)
 
 
 class ImageBatchToImageList:


### PR DESCRIPTION
## Problem

Users were encountering intermittent errors when running the Reactor Masking Helper in ComfyUI. Specifically:

1. **CPU/GPU mismatch**
   Some input tensors were on CPU while others were on GPU, causing:

   ```
   RuntimeError: Expected all tensors to be on the same device
   ```

   when concatenating.

2. **Shape mismatches**
   Even when tensors were on the same device, concatenation sometimes failed with:

   ```
   Sizes of tensors must match except in dimension 0
   ```

   because images had differing height, width, or channel counts.

These issues made the node unreliable, especially when combining images from multiple sources or nodes.

---

## Solution

* **Device consistency:** All tensors are moved to the same device before concatenation.
* **Batch dimension handling:** Single images are converted to batches safely to support concatenation along `dim=0`.
* **Spatial alignment:** Images with mismatched height/width are upscaled to match the first image in the list.
* **Channel alignment:** Images with different channel counts are truncated to the minimum channel count to prevent shape mismatch errors.

---
