### PR TITLE
fix wildcard file encoding

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -360,11 +360,11 @@ def get_wildcard_value(key):
 def load_txt_wildcard(file_path):
     """Load a .txt wildcard file"""
     try:
-        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+        with open(file_path, 'r', encoding="UTF-8") as f:
             lines = f.read().splitlines()
             return [x for x in lines if x.strip() and not x.strip().startswith('#')]
     except (yaml.reader.ReaderError, UnicodeDecodeError):
-        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+        with open(file_path, 'r', encoding="ISO-8859-1") as f:
             lines = f.read().splitlines()
             return [x for x in lines if x.strip() and not x.strip().startswith('#')]
 
@@ -374,10 +374,10 @@ def load_yaml_wildcard(file_path, key_prefix=''):
     global loaded_wildcards
 
     try:
-        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+        with open(file_path, 'r', encoding="UTF-8") as f:
             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
     except (yaml.reader.ReaderError, UnicodeDecodeError):
-        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+        with open(file_path, 'r', encoding="ISO-8859-1") as f:
             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
 
     if not yaml_data:
@@ -480,11 +480,11 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                 else:
                     # Load data immediately (original behavior)
                     try:
-                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                        with open(file_path, 'r', encoding="UTF-8") as f:
                             lines = f.read().splitlines()
                             wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
-                    except yaml.reader.ReaderError:
-                        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                    except (yaml.reader.ReaderError, UnicodeDecodeError):
+                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
                             lines = f.read().splitlines()
                             wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
             elif file.endswith('.yaml') or file.endswith('.yml'):
@@ -501,10 +501,10 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                 else:
                     # Load data immediately (original behavior)
                     try:
-                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                        with open(file_path, 'r', encoding="UTF-8") as f:
                             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
-                    except yaml.reader.ReaderError:
-                        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                    except (yaml.reader.ReaderError, UnicodeDecodeError):
+                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
                             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
 
                     for k, v in yaml_data.items():


### PR DESCRIPTION
This pull request modifies order of assumed encoding when opening wildcard files.

Current logic is opening with ISO-8859-1 then, when error happens, falls back to UTF-8.
In this logic, when there are unicode characters in the wildcard file, it breaks unicode character to Latin-1, breaking unicode characters. When there are lora file with unicode character(for example, 漢字.safetensors), then try to load it, (i. e., <lora:漢字:1>) braking file names thus fails to load lora.

This change fixes this issue.

Below is summary by copilot.

------

This pull request updates the file encoding handling logic for reading wildcard `.txt` and `.yaml` files in `modules/impact/wildcards.py`. The main improvement is standardizing the default file encoding to `UTF-8` for initial reads and switching to `ISO-8859-1` only if a Unicode-related error occurs. This should improve compatibility and reduce issues with file reading across different environments.

**File encoding handling improvements:**

* Changed the default encoding to `UTF-8` when opening `.txt` and `.yaml` wildcard files, and now only fall back to `ISO-8859-1` if a `yaml.reader.ReaderError` or `UnicodeDecodeError` is encountered. (`load_txt_wildcard`, `load_yaml_wildcard`, `read_wildcard_dict`) [[1]](diffhunk://#diff-253418b7f0cded8bd529e776775a173e775d953847dd1590803cc19dd7a14905L363-R367) [[2]](diffhunk://#diff-253418b7f0cded8bd529e776775a173e775d953847dd1590803cc19dd7a14905L377-R380) [[3]](diffhunk://#diff-253418b7f0cded8bd529e776775a173e775d953847dd1590803cc19dd7a14905L483-R487) [[4]](diffhunk://#diff-253418b7f0cded8bd529e776775a173e775d953847dd1590803cc19dd7a14905L504-R507)
* Updated exception handling to consistently catch both `yaml.reader.ReaderError` and `UnicodeDecodeError` when attempting to read files. [[1]](diffhunk://#diff-253418b7f0cded8bd529e776775a173e775d953847dd1590803cc19dd7a14905L483-R487) [[2]](diffhunk://#diff-253418b7f0cded8bd529e776775a173e775d953847dd1590803cc19dd7a14905L504-R507)