### PR TITLE
fix(PreviewBridge): ComfyUI v1.34+ compatibility - widget.value non-configurable

### DIFF
--- a/js/impact-image-util.js
+++ b/js/impact-image-util.js
@@ -75,47 +75,36 @@ app.registerExtension({
 
 	nodeCreated(node, app) {
 		if(node.comfyClass == "PreviewBridge" || node.comfyClass == "PreviewBridgeLatent") {
+			if (!node.widgets) {
+				return;
+			}
+
 			let w = node.widgets.find(obj => obj.name === 'image');
+			if (!w) {
+				return;
+			}
+
 			node._imgs = [new Image()];
 			node.imageIndex = 0;
 
-			Object.defineProperty(w, 'value', {
-				async set(v) {
-					if(w._lock)
-						return;
-
-					const stackTrace = new Error().stack;
-					if(stackTrace.includes('presetText.js'))
-						return;
-
-					var image = new Image();
-					if(v && v.constructor == String && v.startsWith('$')) {
-						// from node feedback
-						let need_to_load = node._imgs[0].src == '';
-						if(await loadImageFromId(image, v, need_to_load)) {
-							w._value = v;
-							if(node._imgs[0].src == '') {
-								node._imgs = [image];
-							}
-						}
-						else {
-							w._value = `$${node.id}-0`;
-						}
-					}
-					else {
-						// from clipspace
-						w._lock = true;
-						w._value = await loadImageFromUrl(image, node.id, v, false);
-						w._lock = false;
-					}
-				},
-				get() {
-					if(w._value == undefined) {
-						w._value = `$${node.id}-0`;
-					}
-					return w._value;
+			// Hook into onExecuted to reset widget value after each execution
+			// This replaces the Object.defineProperty approach which fails on
+			// ComfyUI v1.34+ where widget.value is non-configurable
+			const origOnExecuted = node.onExecuted;
+			node.onExecuted = async function(output) {
+				// Get the actual preview image path from execution output
+				// and register it to get the proper preview bridge ID
+				if (output && output.images && output.images.length > 0) {
+					const img = output.images[0];
+					const path = `PreviewBridge/${img.filename} [temp]`;
+					const pb_id = await loadImageFromUrl(new Image(), node.id, path, false);
+					w.value = pb_id;
 				}
-			});
+
+				if (origOnExecuted) {
+					origOnExecuted.call(this, output);
+				}
+			};
 
 			Object.defineProperty(node, 'imgs', {
 				set(v) {
@@ -145,6 +134,17 @@ app.registerExtension({
 			let path_widget = node.widgets.find(obj => obj.name === 'image');
 			let w = node.widgets.find(obj => obj.name === 'image_data');
 			let stw_widget = node.widgets.find(obj => obj.name === 'save_to_workflow');
+
+			if (!w) {
+				return;
+			}
+
+			// Check if widget.value is configurable before trying to redefine it
+			const descriptor = Object.getOwnPropertyDescriptor(w, 'value');
+			if (descriptor && !descriptor.configurable) {
+				return;
+			}
+
 			w._value = "";
 
 			Object.defineProperty(w, 'value', {

--- a/js/impact-image-util.js
+++ b/js/impact-image-util.js
@@ -92,13 +92,22 @@ app.registerExtension({
 			// ComfyUI v1.34+ where widget.value is non-configurable
 			const origOnExecuted = node.onExecuted;
 			node.onExecuted = async function(output) {
-				// Get the actual preview image path from execution output
-				// and register it to get the proper preview bridge ID
-				if (output && output.images && output.images.length > 0) {
-					const img = output.images[0];
-					const path = `PreviewBridge/${img.filename} [temp]`;
-					const pb_id = await loadImageFromUrl(new Image(), node.id, path, false);
-					w.value = pb_id;
+				// Check if we should preserve clipspace path (user-drawn mask)
+				const outputImage = output?.images?.[0];
+				const isNewTempFile = outputImage &&
+				                      outputImage.subfolder === 'PreviewBridge' &&
+				                      outputImage.type === 'temp';
+				const isClipspacePath = w.value &&
+				                        (w.value.includes('clipspace') || w.value.includes('[input]'));
+
+				// Only update widget if image changed OR not a clipspace path
+				if (!(isClipspacePath && !isNewTempFile)) {
+					if (output && output.images && output.images.length > 0) {
+						const img = output.images[0];
+						const path = `PreviewBridge/${img.filename} [temp]`;
+						const pb_id = await loadImageFromUrl(new Image(), node.id, path, false);
+						w.value = pb_id;
+					}
 				}
 
 				if (origOnExecuted) {

--- a/modules/impact/bridge_nodes.py
+++ b/modules/impact/bridge_nodes.py
@@ -81,9 +81,52 @@ class PreviewBridge:
         return image, mask.unsqueeze(0), ui_item
 
     @staticmethod
+    def load_mask_from_clipspace(clipspace_path):
+        """Load just the mask from a clipspace file directly from disk.
+
+        This bypasses the preview_bridge_image_id_map lookup, which is needed
+        when we want to restore a mask from clipspace but the path isn't registered yet.
+        This is necessary because ComfyUI v1.34+ broke the JS widget.value setter
+        that used to register clipspace paths via API.
+        """
+        # Remove [input] suffix if present
+        clean_path = clipspace_path.replace(" [input]", "").replace("[input]", "")
+
+        # Try to find the actual clipspace file
+        input_dir = folder_paths.get_input_directory()
+        potential_paths = [
+            clean_path,
+            os.path.join(input_dir, clean_path),
+            os.path.join(input_dir, "clipspace", os.path.basename(clean_path)),
+        ]
+
+        actual_file = None
+        for path in potential_paths:
+            if os.path.isfile(path):
+                actual_file = path
+                break
+
+        if actual_file is None:
+            return None
+
+        try:
+            i = Image.open(actual_file)
+            i = ImageOps.exif_transpose(i)
+
+            if 'A' in i.getbands():
+                mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
+                mask = 1. - torch.from_numpy(mask)
+                return mask.unsqueeze(0)
+            else:
+                return None
+        except Exception as e:
+            logging.warning(f"[PreviewBridge] Error loading mask from clipspace: {e}")
+            return None
+
+    @staticmethod
     def register_clipspace_image(clipspace_path, node_id):
         """Register a clipspace image file in the preview bridge system.
-        
+
         This handles the case where ComfyUI's mask editor creates clipspace files
         that need to be integrated with the preview bridge system.
         """
@@ -160,11 +203,24 @@ class PreviewBridge:
             # Exception: when restore_mask is "always", restore even with new images
             # Exception: when restore_mask is "if_same_size", allow restoration to check size compatibility
             if restore_mask != "never" and (not images_changed or restore_mask in ["always", "if_same_size"]):
-                mask = core.preview_bridge_last_mask_cache.get(unique_id)
+                # Check if widget value points to a clipspace path (user edited mask)
+                # Clipspace paths take priority over cache because they represent the user's latest edit
+                is_clipspace_path = image and ("clipspace" in image.lower() or "[input]" in image)
+
+                mask = None
+
+                # Try clipspace FIRST - user's most recent edit takes priority
+                if is_clipspace_path:
+                    clipspace_mask = PreviewBridge.load_mask_from_clipspace(image)
+                    if clipspace_mask is not None and not torch.all(clipspace_mask == 0):
+                        mask = clipspace_mask
+
+                # Fall back to cache if clipspace failed or wasn't available
                 if mask is None:
-                    mask = None
-                elif restore_mask == "if_same_size" and mask.shape[1:] != images.shape[1:3]:
-                    # For if_same_size, clear mask if dimensions don't match
+                    mask = core.preview_bridge_last_mask_cache.get(unique_id)
+
+                # Check size compatibility for if_same_size mode
+                if mask is not None and restore_mask == "if_same_size" and mask.shape[1:] != images.shape[1:3]:
                     mask = None
                 # For "always", keep the mask regardless of size
             else:
@@ -440,11 +496,24 @@ class PreviewBridgeLatent:
                 # Exception: when restore_mask is "always", restore even with new latents
                 # Exception: when restore_mask is "if_same_size", allow restoration to check size compatibility
                 if restore_mask != "never" and (not latent_changed or restore_mask in ["always", "if_same_size"]):
-                    mask = core.preview_bridge_last_mask_cache.get(unique_id)
+                    # Check if widget value points to a clipspace path (user edited mask)
+                    # Clipspace paths take priority over cache because they represent the user's latest edit
+                    is_clipspace_path = image and ("clipspace" in image.lower() or "[input]" in image)
+
+                    mask = None
+
+                    # Try clipspace FIRST - user's most recent edit takes priority
+                    if is_clipspace_path:
+                        clipspace_mask = PreviewBridge.load_mask_from_clipspace(image)
+                        if clipspace_mask is not None and not torch.all(clipspace_mask == 0):
+                            mask = clipspace_mask
+
+                    # Fall back to cache if clipspace failed or wasn't available
                     if mask is None:
-                        mask = None
-                    elif restore_mask == "if_same_size" and mask.shape[1:] != decoded_image.shape[1:3]:
-                        # For if_same_size, clear mask if dimensions don't match
+                        mask = core.preview_bridge_last_mask_cache.get(unique_id)
+
+                    # Check size compatibility for if_same_size mode
+                    if mask is not None and restore_mask == "if_same_size" and mask.shape[1:] != decoded_image.shape[1:3]:
                         mask = None
                     # For "always", keep the mask regardless of size
                 else:


### PR DESCRIPTION
After ComfyUI updated to v1.34+ with the Vue-based frontend, the ImpactPack PreviewBridge node broke in two ways:

1. MaskEditor showed wrong image: Widget value retained old clipspace paths, causing MaskEditor to display the previous image instead of the newly generated one
2. restore_mask settings ignored: Mask restoration ("never", "if_same_size", "always") stopped working entirely

## Debugging revealed a few causes...

ComfyUI v1.34+ made `widget.value` non-configurable, causing `Object.defineProperty()` to fail silently (error swallowed by extension system).

The original JavaScript code relied on intercepting `widget.value` changes to:
1. Register clipspace paths via API call to `/impact/set/pb_id_image`
2. Track image state for proper display

Without this registration, `PreviewBridge.load_image()` couldn't find clipspace paths in `preview_bridge_image_id_map`, returning empty 64x64 placeholder masks instead of actual user-drawn masks.

## Solution

### JavaScript (`impact-image-util.js`)
- Replace `Object.defineProperty(w, 'value', ...)` with `node.onExecuted` hook
- Register preview images after each execution via existing API
- Add null checks for widgets
- Add `configurable` check for ImageReceiver to prevent silent failures

### Python (`bridge_nodes.py`)
- Add `load_mask_from_clipspace()` to read masks directly from disk (bypasses broken registration)
- Clipspace paths now take priority over cache (user's latest edit preserved)
- Apply same fix to `PreviewBridgeLatent`

## Demo Video

[![Test-Demo-Image](https://github.com/user-attachments/assets/db8efb63-27b5-47eb-b5f2-2fcea84af515)](https://youtu.be/YoFrxmT7dqk)

Demonstrates:
- `block` setting: "if_empty_mask" and "never" both work
- `restore_mask` modes: "never", "if_same_size", "always" all function correctly
- Edited masks persist across workflow runs

## Testing Summary

| restore_mask | Image Changed | Expected | Result |
|--------------|---------------|----------|--------|
| [never](https://youtu.be/YoFrxmT7dqk?t=23) | Yes | Mask cleared | ✅ |
| [if_same_size](https://youtu.be/YoFrxmT7dqk?t=47) | Yes (same size) | Mask preserved | ✅ |
| [if_same_size](https://youtu.be/YoFrxmT7dqk?t=89) | Yes (diff size) | Mask cleared | ✅ |
| [always](https://youtu.be/YoFrxmT7dqk?t=63) | Yes (any size) | Mask preserved | ✅ |

## Backwards Compatibility

No breaking API changes. Existing workflows unaffected. Fix specifically targets ComfyUI v1.34+ frontend compatibility while maintaining support for older versions.

## Related

- Builds on #1009 (clipspace registration infrastructure)
- ComfyUI frontend v1.34+ changelog: widget property encapsulation in Vue components