### PR TITLE
use static seed for wildcard-nodes if text is not seed dependent

### DIFF
--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import os
+import re
 import random
 import threading
 import traceback
@@ -28,6 +29,9 @@ sam_lock = threading.Condition()
 
 last_prepare_data = None
 
+IMPACT_SYNTAX_RE = re.compile(
+    r"(__[^\r\n]+?__)|(?<!\\)\{[^{}\r\n]*(\||\$\$|::)[^{}\r\n]*\}"
+)
 
 def async_prepare_sam(image_dir, model_name, filename):
     with sam_lock:
@@ -507,6 +511,32 @@ def find_input_value(input_node, prompt, input_type=int, input_keys=('value',)):
     
     return input_val
 
+def _is_seed_dependent_text(text: str) -> bool:
+    return isinstance(text, str) and (IMPACT_SYNTAX_RE.search(text) is not None)
+
+
+def _resolve_string_input(value, prompt):
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, list) and value:
+        node_id = value[0]
+        node = prompt.get(node_id)
+        if not node:
+            return None
+
+        node_inputs = node.get("inputs", {})
+
+        for key in ("text", "string", "value", "prompt", "populated_text", "wildcard_text"):
+            v = node_inputs.get(key)
+            if isinstance(v, str):
+                return v
+
+        for v in node_inputs.values():
+            if isinstance(v, str):
+                return v
+
+    return None
 
 def onprompt_populate_wildcards(json_data):
     prompt = json_data['prompt']
@@ -524,6 +554,16 @@ def onprompt_populate_wildcards(json_data):
                     new_mode = 'fixed'
 
                 inputs['mode'] = new_mode
+                
+            try:
+                text_to_check = _resolve_string_input(inputs.get("populated_text"), prompt)
+                if not isinstance(text_to_check, str):
+                    text_to_check = _resolve_string_input(inputs.get("wildcard_text"), prompt)
+
+                if isinstance(text_to_check, str) and not _is_seed_dependent_text(text_to_check):
+                    inputs["seed"] = 0
+            except Exception:
+                pass
 
             if inputs['mode'] == 'populate' and isinstance(inputs['populated_text'], str):
                 if isinstance(inputs['seed'], list):

--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -512,31 +512,45 @@ def find_input_value(input_node, prompt, input_type=int, input_keys=('value',)):
     return input_val
 
 def _is_seed_dependent_text(text: str) -> bool:
-    return isinstance(text, str) and (IMPACT_SYNTAX_RE.search(text) is not None)
+    """True if this *string* contains Impact wildcard/dynamic syntax."""
+    return isinstance(text, str) and bool(text) and (IMPACT_SYNTAX_RE.search(text) is not None)
 
+def _value_might_be_seed_dependent(value, prompt, visited=None, depth: int = 0, max_depth: int = 30) -> bool:
+    """
+    Recursively scan an input value (literal string or link [node_id, output_idx]) and its
+    upstream inputs to determine whether Impact syntax might be present.
 
-def _resolve_string_input(value, prompt):
+    Returns True if seed might affect output.
+    Returns False only when we can be reasonably sure there is no syntax anywhere upstream.
+    """
+    if visited is None:
+        visited = set()
+
+    if depth > max_depth:
+        return True
+
     if isinstance(value, str):
-        return value
+        return _is_seed_dependent_text(value)
 
     if isinstance(value, list) and value:
         node_id = value[0]
+        if node_id in visited:
+            return True
+        visited.add(node_id)
+
         node = prompt.get(node_id)
         if not node:
-            return None
+            return True
 
         node_inputs = node.get("inputs", {})
 
-        for key in ("text", "string", "value", "prompt", "populated_text", "wildcard_text"):
-            v = node_inputs.get(key)
-            if isinstance(v, str):
-                return v
+        for vv in node_inputs.values():
+            if _value_might_be_seed_dependent(vv, prompt, visited, depth + 1, max_depth):
+                return True
 
-        for v in node_inputs.values():
-            if isinstance(v, str):
-                return v
+        return False
 
-    return None
+    return True
 
 def onprompt_populate_wildcards(json_data):
     prompt = json_data['prompt']
@@ -546,7 +560,6 @@ def onprompt_populate_wildcards(json_data):
         if 'class_type' in v and (v['class_type'] == 'ImpactWildcardEncode' or v['class_type'] == 'ImpactWildcardProcessor'):
             inputs = v['inputs']
 
-            # legacy adapter
             if isinstance(inputs['mode'], bool):
                 if inputs['mode']:
                     new_mode = 'populate'
@@ -554,13 +567,13 @@ def onprompt_populate_wildcards(json_data):
                     new_mode = 'fixed'
 
                 inputs['mode'] = new_mode
-                
-            try:
-                text_to_check = _resolve_string_input(inputs.get("populated_text"), prompt)
-                if not isinstance(text_to_check, str):
-                    text_to_check = _resolve_string_input(inputs.get("wildcard_text"), prompt)
 
-                if isinstance(text_to_check, str) and not _is_seed_dependent_text(text_to_check):
+            try:
+                value_to_check = inputs.get("populated_text", None)
+                if value_to_check is None:
+                    value_to_check = inputs.get("wildcard_text", None)
+
+                if isinstance(inputs.get("seed", None), int) and value_to_check is not None and not _value_might_be_seed_dependent(value_to_check, prompt):
                     inputs["seed"] = 0
             except Exception:
                 pass


### PR DESCRIPTION
### Why this change?
I use the wildcard nodes in several dynamic workflows, often inside subgraphs, where I pass multiline prompts directly into the `populated_text `input. In practice, I frequently tweak settings later in the graph and re-run the workflow. Right now, that often forces a full re-execution from the wildcard node onward because the node’s seed changes—even when the prompt contains no wildcard/dynamic syntax and the output would be identical.

Manually fixing the seed in every subgraph isn’t very practical, and adding additional seed controls outside the subgraphs just to stabilize this one node would add clutter. This change avoids unnecessary re-runs by normalizing the seed when it cannot affect the processed text, while keeping existing behavior intact for prompts that actually use seed-dependent syntax.

### Technical changes
When `ImpactWildcardProcessor `or `ImpactWildcardEncode `is used with the seed control set to randomize / increment / decrement, ComfyUI updates the seed value on every run. Even if the prompt contains no wildcard or dynamic syntax, the changed seed ends up in the queued prompt JSON, which forces downstream nodes to re-execute.

This change detects when the effective input text contains no seed-dependent Impact syntax and, in that case, normalizes the seed to a fixed value (0) before execution. This prevents unnecessary prompt “population” work and avoids re-running the workflow when the actual prompt content has not changed.

When the input text is provided via a link, the handler walks upstream through the linked nodes and inspects their text inputs to determine whether any Impact wildcard/dynamic syntax (i.e. seed-dependent content) could be present. Only when it can confidently determine that no seed-dependent syntax exists anywhere upstream does it normalize the seed to 0 internally, preventing unnecessary downstream re-execution. This approach also works when text is routed through subgraphs or composed via concat/other string nodes. The normalization is only applied when the seed itself is a direct integer input (not a linked value), so externally controlled seeds are never overridden.
