### PR TITLE
Add FaceDetailer tiled VAE controls and optional post_detail_shrink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 *.ini
 wildcards/**
 .vscode/
+.vs/
 .idea/
 subpack
 impact_subpack

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -60,13 +60,12 @@ ADDITIONAL_SCHEDULERS = ['AYS SDXL', 'AYS SD1', 'AYS SVD', 'GITS[coeff=1.2]', 'L
 
 
 class _ImpactTiledEncodeProxyVAE:
-    def __init__(self, vae, tile_size=512, overlap=64):
+    def __init__(self, vae):
         self._vae = vae
-        self._tile_size = tile_size
-        self._overlap = overlap
 
     def encode(self, pixels):
-        return self._vae.encode_tiled(pixels, tile_x=self._tile_size, tile_y=self._tile_size, overlap=self._overlap)
+        tile_size, overlap = utils.get_vae_tiled_encode_settings(pixels)
+        return self._vae.encode_tiled(pixels, tile_x=tile_size, tile_y=tile_size, overlap=overlap)
 
     def __getattr__(self, name):
         return getattr(self._vae, name)

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -441,7 +441,12 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if detailer_hook is not None:
         refined_image = detailer_hook.post_decode(refined_image)
 
-    # downscale
+    # Final geometry fix before paste-back.
+    #
+    # This boundary is hit immediately after VAE decode, where prior failures were
+    # observed in native resize paths. Keep the returned crop on CPU, avoid bicubic
+    # for post-decode paste-back resize, and crop/pad tiny VAE multiple differences
+    # instead of interpolating them.
 
     # workaround: support WAN as an i2i model
     if len(refined_image.shape) == 5:
@@ -449,11 +454,19 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
 
     target_w = int(w)
     target_h = int(h)
-    if utils.tensor_get_size(refined_image) != (target_w, target_h):
-        refined_image = utils.tensor_resize(refined_image, target_w, target_h)
 
-    # prevent mixing of device
-    refined_image = refined_image.cpu()
+    if torch.is_tensor(refined_image) and refined_image.is_cuda:
+        logging.info(f"Detailer: synchronizing decoded crop before CPU paste-back {tuple(refined_image.shape)}")
+        torch.cuda.synchronize(refined_image.device)
+
+    # prevent mixing of device and keep the fragile post-decode geometry path on CPU
+    refined_image = refined_image.detach().cpu()
+
+    cur_w, cur_h = utils.tensor_get_size(refined_image)
+    if (cur_w, cur_h) != (target_w, target_h):
+        logging.info(f"Detailer: final crop geometry fix {(cur_w, cur_h)} -> {(target_w, target_h)}")
+        refined_image = utils.tensor_resize_for_detailer_output(refined_image, target_w, target_h)
+        logging.info(f"Detailer: final crop geometry fix complete {tuple(refined_image.shape)}")
 
     # don't convert to latent - latent break image
     # preserving pil is much better

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -331,11 +331,35 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
             logging.info(f"Detailer: segment skip [zero size={new_w, new_h}]")
             return None, None
     else:
-        if upscale <= 1.0 or new_w == 0 or new_h == 0:
-            logging.info("Detailer: force inpaint")
+        if new_w == 0 or new_h == 0:
+            logging.info("Detailer: force inpaint [zero computed size; using original crop size]")
             upscale = 1.0
             new_w = w
             new_h = h
+        elif upscale <= 1.0:
+            # Force-inpaint means "do not skip this segment"; it should not silently
+            # bypass the existing guide_size/max_size working-resolution controls.
+            #
+            # The old behavior reset upscale to 1.0 whenever the crop was already
+            # larger than guide_size. For large person/full-frame detections this
+            # pushed FaceDetailer into full-frame VAE encode/decode, e.g. a
+            # 1900x2732 crop, which is both unnecessary for a detailer pass and a
+            # WSL/CUDA/model-loading wedge trigger.
+            logging.info(
+                "Detailer: force inpaint [keeping capped working size] "
+                f"crop={(w, h)} -> working={(new_w, new_h)} upscale={upscale}"
+            )
+
+    if max_size > 0 and (new_w > max_size or new_h > max_size):
+        old_new_w, old_new_h = new_w, new_h
+        cap_scale = max_size / max(new_w, new_h)
+        upscale *= cap_scale
+        new_w = max(1, int(w * upscale))
+        new_h = max(1, int(h * upscale))
+        logging.info(
+            "Detailer: max_size cap "
+            f"{(old_new_w, old_new_h)} -> {(new_w, new_h)} max_size={max_size}"
+        )
 
     if detailer_hook is not None:
         new_w, new_h = detailer_hook.touch_scaled_size(new_w, new_h)

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -358,7 +358,8 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if detailer_hook is None or not detailer_hook.get_skip_sampling():
         if noise_mask is not None and inpaint_model:
             imc_encode = nodes.InpaintModelConditioning().encode
-            imc_vae = _ImpactTiledEncodeProxyVAE(vae, tile_size=vae_tile_size, overlap=vae_tile_overlap) if vae_tiled_encode else vae
+            use_tiled_vae = vae_tiled_encode or auto_vae_tiled_encode or (vae_tile_size is not None and vae_tile_size > 0)
+            imc_vae = _ImpactTiledEncodeProxyVAE(vae, tile_size=vae_tile_size, overlap=vae_tile_overlap) if use_tiled_vae else vae
             if 'noise_mask' in inspect.signature(imc_encode).parameters:
                 positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, imc_vae, mask=noise_mask, noise_mask=True)
             else:

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -331,15 +331,24 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
             logging.info(f"Detailer: segment skip [zero size={new_w, new_h}]")
             return None, None
     else:
-        if new_w == 0 or new_h == 0 or upscale <= 1.0:
-            # Preserve Impact Pack's original force-inpaint quality behavior:
-            # force-inpaint keeps the detected crop at its native crop size instead
-            # of downscaling to guide_size/max_size and later upscaling it back for
-            # paste. The earlier cap reduced detailed-area quality.
-            logging.info("Detailer: force inpaint")
+        if new_w == 0 or new_h == 0:
+            logging.info("Detailer: force inpaint [zero computed size; using original crop size]")
             upscale = 1.0
             new_w = w
             new_h = h
+        elif upscale <= 1.0:
+            # Force-inpaint means "do not skip this segment"; it should not silently
+            # bypass the existing guide_size/max_size working-resolution controls.
+            #
+            # The old behavior reset upscale to 1.0 whenever the crop was already
+            # larger than guide_size. For large person/full-frame detections this
+            # pushed FaceDetailer into full-frame VAE encode/decode, e.g. a
+            # 1900x2732 crop, which is both unnecessary for a detailer pass and a
+            # WSL/CUDA/model-loading wedge trigger.
+            logging.info(
+                "Detailer: force inpaint [keeping capped working size] "
+                f"crop={(w, h)} -> working={(new_w, new_h)} upscale={upscale}"
+            )
 
     if max_size > 0 and (new_w > max_size or new_h > max_size):
         old_new_w, old_new_h = new_w, new_h

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -331,24 +331,15 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
             logging.info(f"Detailer: segment skip [zero size={new_w, new_h}]")
             return None, None
     else:
-        if new_w == 0 or new_h == 0:
-            logging.info("Detailer: force inpaint [zero computed size; using original crop size]")
+        if new_w == 0 or new_h == 0 or upscale <= 1.0:
+            # Preserve Impact Pack's original force-inpaint quality behavior:
+            # force-inpaint keeps the detected crop at its native crop size instead
+            # of downscaling to guide_size/max_size and later upscaling it back for
+            # paste. The earlier cap reduced detailed-area quality.
+            logging.info("Detailer: force inpaint")
             upscale = 1.0
             new_w = w
             new_h = h
-        elif upscale <= 1.0:
-            # Force-inpaint means "do not skip this segment"; it should not silently
-            # bypass the existing guide_size/max_size working-resolution controls.
-            #
-            # The old behavior reset upscale to 1.0 whenever the crop was already
-            # larger than guide_size. For large person/full-frame detections this
-            # pushed FaceDetailer into full-frame VAE encode/decode, e.g. a
-            # 1900x2732 crop, which is both unnecessary for a detailer pass and a
-            # WSL/CUDA/model-loading wedge trigger.
-            logging.info(
-                "Detailer: force inpaint [keeping capped working size] "
-                f"crop={(w, h)} -> working={(new_w, new_h)} upscale={upscale}"
-            )
 
     if max_size > 0 and (new_w > max_size or new_h > max_size):
         old_new_w, old_new_h = new_w, new_h

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -358,7 +358,7 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if detailer_hook is None or not detailer_hook.get_skip_sampling():
         if noise_mask is not None and inpaint_model:
             imc_encode = nodes.InpaintModelConditioning().encode
-            use_tiled_vae = vae_tiled_encode or auto_vae_tiled_encode or (vae_tile_size is not None and vae_tile_size > 0)
+            use_tiled_vae = vae_tiled_encode or auto_vae_tiled_encode or (vae_tile_size is not None and vae_tile_size > 0) or (vae_tile_overlap is not None and vae_tile_overlap > 0)
             imc_vae = _ImpactTiledEncodeProxyVAE(vae, tile_size=vae_tile_size, overlap=vae_tile_overlap) if use_tiled_vae else vae
             if 'noise_mask' in inspect.signature(imc_encode).parameters:
                 positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, imc_vae, mask=noise_mask, noise_mask=True)

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -413,7 +413,10 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if len(refined_image.shape) == 5:
         refined_image = refined_image.squeeze(0)
 
-    refined_image = utils.tensor_resize(refined_image, w, h)
+    target_w = int(w)
+    target_h = int(h)
+    if utils.tensor_get_size(refined_image) != (target_w, target_h):
+        refined_image = utils.tensor_resize(refined_image, target_w, target_h)
 
     # prevent mixing of device
     refined_image = refined_image.cpu()

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -58,6 +58,19 @@ current_prompt = None
 
 ADDITIONAL_SCHEDULERS = ['AYS SDXL', 'AYS SD1', 'AYS SVD', 'GITS[coeff=1.2]', 'LTXV[default]', 'OSS FLUX', 'OSS Wan', 'OSS Chroma']
 
+
+class _ImpactTiledEncodeProxyVAE:
+    def __init__(self, vae, tile_size=512, overlap=64):
+        self._vae = vae
+        self._tile_size = tile_size
+        self._overlap = overlap
+
+    def encode(self, pixels):
+        return self._vae.encode_tiled(pixels, tile_x=self._tile_size, tile_y=self._tile_size, overlap=self._overlap)
+
+    def __getattr__(self, name):
+        return getattr(self._vae, name)
+
 def get_schedulers():
     return list(comfy.samplers.SCHEDULER_HANDLERS) + ADDITIONAL_SCHEDULERS
 
@@ -343,11 +356,12 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if detailer_hook is None or not detailer_hook.get_skip_sampling():
         if noise_mask is not None and inpaint_model:
             imc_encode = nodes.InpaintModelConditioning().encode
+            imc_vae = _ImpactTiledEncodeProxyVAE(vae) if vae_tiled_encode else vae
             if 'noise_mask' in inspect.signature(imc_encode).parameters:
-                positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, vae, mask=noise_mask, noise_mask=True)
+                positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, imc_vae, mask=noise_mask, noise_mask=True)
             else:
                 logging.warning("[Impact Pack] ComfyUI is an outdated version.")
-                positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, vae, noise_mask)
+                positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, imc_vae, noise_mask)
         else:
             latent_image = utils.to_latent_image(upscaled_image, vae, vae_tiled_encode=vae_tiled_encode)
             if noise_mask is not None:

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -59,6 +59,30 @@ current_prompt = None
 ADDITIONAL_SCHEDULERS = ['AYS SDXL', 'AYS SD1', 'AYS SVD', 'GITS[coeff=1.2]', 'LTXV[default]', 'OSS FLUX', 'OSS Wan', 'OSS Chroma']
 
 
+def _impact_is_wsl():
+    try:
+        return "microsoft" in os.uname().release.lower() or "wsl" in os.uname().release.lower()
+    except Exception:
+        return False
+
+
+def _impact_env_enabled(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _impact_should_release_sam_device():
+    # Moving SAM/SAM2 back to CPU after every FaceDetailer frame is a heavy
+    # CPU/GPU model-transfer boundary. On WSL this has repeatedly become a
+    # full-driver wedge point after detector output and before detailer segments.
+    # Keep the old behavior available for low-VRAM diagnostics.
+    if _impact_is_wsl() and not _impact_env_enabled("IMPACT_WSL_RELEASE_SAM_DEVICE", False):
+        return False
+    return True
+
+
 def _move_latent_samples_to_cpu_for_decode(latent, label="detailer"):
     """Release sampler-side CUDA temporaries before VAE decode/model load.
 
@@ -712,7 +736,12 @@ class SAMWrapper:
 
     def release_device(self):
         if self.is_auto_mode:
+            if not _impact_should_release_sam_device():
+                logging.info("[Impact Pack] keeping SAM model on current device after prediction on WSL; set IMPACT_WSL_RELEASE_SAM_DEVICE=1 to release it to CPU after each prediction")
+                return
+            logging.info("[Impact Pack] releasing SAM model to CPU")
             self.model.to(device="cpu")
+            logging.info("[Impact Pack] released SAM model to CPU")
 
     def predict(self, image, points, plabs, bbox, threshold):
         predictor = SamPredictor(self.model)
@@ -746,10 +775,15 @@ class SAM2Wrapper:
 
     def release_device(self):
         if self.is_auto_mode:
+            if not _impact_should_release_sam_device():
+                logging.info("[Impact Pack] keeping SAM2 model on current device after prediction on WSL; set IMPACT_WSL_RELEASE_SAM_DEVICE=1 to release it to CPU after each prediction")
+                return
+            logging.info("[Impact Pack] releasing SAM2 model to CPU")
             if self.image_predictor:
                 self.image_predictor.model.to(device="cpu")
             if self.video_predictor:
                 self.video_predictor.to(device="cpu")
+            logging.info("[Impact Pack] released SAM2 model to CPU")
 
     def predict(self, image, points, plabs, bbox, threshold):
         if not is_sam2_available:
@@ -871,10 +905,15 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
     else:
         sam_obj = sam.sam_wrapper
 
+    logging.info(f"[Impact Pack] SAM mask start: segs={len(segs[1])} hint={detection_hint} dilation={dilation} bbox_expansion={bbox_expansion}")
+    logging.info("[Impact Pack] SAM prepare_device start")
     sam_obj.prepare_device()
+    logging.info("[Impact Pack] SAM prepare_device complete")
 
     try:
-        image = np.clip(255. * image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+        logging.info(f"[Impact Pack] SAM image conversion start shape={tuple(image.shape)} device={image.device}")
+        image = np.clip(255. * image.detach().cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+        logging.info(f"[Impact Pack] SAM image conversion complete shape={image.shape}")
 
         total_masks = []
 
@@ -897,7 +936,9 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
                 else:
                     plabs.append(1)
 
+            logging.info(f"[Impact Pack] SAM predict mask-points start points={len(points)}")
             detected_masks = sam_obj.predict(image, points, plabs, None, threshold)
+            logging.info(f"[Impact Pack] SAM predict mask-points complete masks={len(detected_masks)}")
             total_masks += detected_masks
 
         else:
@@ -966,19 +1007,30 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
                     points += npoints
                     plabs += nplabs
 
+                logging.info(
+                    f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} start "
+                    f"points={len(points)} bbox={dilated_bbox}"
+                )
                 detected_masks = sam_obj.predict(image, points, plabs, dilated_bbox, threshold)
+                logging.info(f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} complete masks={len(detected_masks)}")
                 total_masks += detected_masks
 
         # merge every collected masks
+        logging.info(f"[Impact Pack] SAM combine masks start count={len(total_masks)}")
         mask = utils.combine_masks2(total_masks)
+        logging.info(f"[Impact Pack] SAM combine masks complete shape={None if mask is None else tuple(mask.shape)}")
 
     finally:
+        logging.info("[Impact Pack] SAM release_device start")
         sam_obj.release_device()
+        logging.info("[Impact Pack] SAM release_device complete")
 
     if mask is not None:
+        logging.info(f"[Impact Pack] SAM postprocess start shape={tuple(mask.shape)}")
         mask = mask.float()
         mask = utils.dilate_mask(mask.cpu().numpy(), dilation)
         mask = torch.from_numpy(mask)
+        logging.info(f"[Impact Pack] SAM postprocess complete shape={tuple(mask.shape)}")
     else:
         size = image.shape[0], image.shape[1]
         mask = torch.zeros(size, dtype=torch.float32, device="cpu")  # empty mask
@@ -1141,10 +1193,15 @@ def make_sam_mask_segmented(sam, segs, image, detection_hint, dilation,
         raise Exception("[Impact Pack] Invalid SAMLoader is connected. Make sure 'SAMLoader (Impact)'.")
 
     sam_obj = sam.sam_wrapper
+    logging.info(f"[Impact Pack] SAM mask start: segs={len(segs[1])} hint={detection_hint} dilation={dilation} bbox_expansion={bbox_expansion}")
+    logging.info("[Impact Pack] SAM prepare_device start")
     sam_obj.prepare_device()
+    logging.info("[Impact Pack] SAM prepare_device complete")
 
     try:
-        image = np.clip(255. * image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+        logging.info(f"[Impact Pack] SAM image conversion start shape={tuple(image.shape)} device={image.device}")
+        image = np.clip(255. * image.detach().cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
+        logging.info(f"[Impact Pack] SAM image conversion complete shape={image.shape}")
 
         total_masks = []
 
@@ -1167,7 +1224,9 @@ def make_sam_mask_segmented(sam, segs, image, detection_hint, dilation,
                 else:
                     plabs.append(1)
 
+            logging.info(f"[Impact Pack] SAM predict mask-points start points={len(points)}")
             detected_masks = sam_obj.predict(image, points, plabs, None, threshold)
+            logging.info(f"[Impact Pack] SAM predict mask-points complete masks={len(detected_masks)}")
             total_masks += detected_masks
 
         else:
@@ -1185,22 +1244,33 @@ def make_sam_mask_segmented(sam, segs, image, detection_hint, dilation,
                                                          mask_hint_threshold, use_small_negative,
                                                          mask_hint_use_negative)
 
+                logging.info(
+                    f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} start "
+                    f"points={len(points)} bbox={dilated_bbox}"
+                )
                 detected_masks = sam_obj.predict(image, points, plabs, dilated_bbox, threshold)
+                logging.info(f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} complete masks={len(detected_masks)}")
 
                 total_masks += detected_masks
 
         # merge every collected masks
+        logging.info(f"[Impact Pack] SAM combine masks start count={len(total_masks)}")
         mask = utils.combine_masks2(total_masks)
+        logging.info(f"[Impact Pack] SAM combine masks complete shape={None if mask is None else tuple(mask.shape)}")
 
     finally:
+        logging.info("[Impact Pack] SAM release_device start")
         sam_obj.release_device()
+        logging.info("[Impact Pack] SAM release_device complete")
 
     mask_working_device = torch.device("cpu")
 
     if mask is not None:
+        logging.info(f"[Impact Pack] SAM postprocess start shape={tuple(mask.shape)}")
         mask = mask.float()
         mask = utils.dilate_mask(mask.cpu().numpy(), dilation)
         mask = torch.from_numpy(mask)
+        logging.info(f"[Impact Pack] SAM postprocess complete shape={tuple(mask.shape)}")
         mask = mask.to(device=mask_working_device)
     else:
         # Extracting batch, height and width

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -59,6 +59,39 @@ current_prompt = None
 ADDITIONAL_SCHEDULERS = ['AYS SDXL', 'AYS SD1', 'AYS SVD', 'GITS[coeff=1.2]', 'LTXV[default]', 'OSS FLUX', 'OSS Wan', 'OSS Chroma']
 
 
+def _move_latent_samples_to_cpu_for_decode(latent, label="detailer"):
+    """Release sampler-side CUDA temporaries before VAE decode/model load.
+
+    FaceDetailer runs sampler -> VAE decode repeatedly for each detected region.
+    On large Flux crops, the sampler can leave cached CUDA allocations around
+    until the next model load boundary.  Moving the refined latent samples to
+    CPU before decode preserves ComfyUI's normal VAE input contract while giving
+    the allocator a clean boundary before AutoencoderKL is requested.
+    """
+    if not isinstance(latent, dict) or "samples" not in latent:
+        return latent
+
+    samples = latent["samples"]
+    if not torch.is_tensor(samples):
+        return latent
+
+    if samples.is_cuda:
+        logging.info(f"[Impact Pack] moving refined latent to CPU before VAE decode ({label}) shape={tuple(samples.shape)}")
+        latent = latent.copy()
+        latent["samples"] = samples.detach().cpu()
+        del samples
+
+        if torch.cuda.is_available():
+            try:
+                if hasattr(model_management, "soft_empty_cache"):
+                    model_management.soft_empty_cache()
+                else:
+                    torch.cuda.empty_cache()
+            except Exception as e:
+                logging.warning(f"[Impact Pack] CUDA cache cleanup before VAE decode failed ({label}): {e}")
+    return latent
+
+
 class _ImpactTiledEncodeProxyVAE:
     def __init__(self, vae, tile_size=0, overlap=0):
         self._vae = vae
@@ -410,6 +443,8 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
 
         if detailer_hook is not None:
             refined_latent = detailer_hook.pre_decode(refined_latent)
+
+        refined_latent = _move_latent_samples_to_cpu_for_decode(refined_latent, label="FaceDetailer")
 
         # non-latent downscale - latent downscale cause bad quality
         start = time.time()

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -341,24 +341,33 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
 
     if noise_mask is not None:
         logging.info("[Impact Pack] enhance_detail[%s] noise mask blur start", detailer_trace)
+        operation_start = time.perf_counter()
         noise_mask = utils.tensor_gaussian_blur_mask(noise_mask, noise_mask_feather)
-        logging.info("[Impact Pack] enhance_detail[%s] noise mask blur complete shape=%s device=%s elapsed=%.3fs",
-                     detailer_trace, tuple(noise_mask.shape), noise_mask.device, time.perf_counter() - detailer_start)
+        operation_end = time.perf_counter()
+        logging.info("[Impact Pack] enhance_detail[%s] noise mask blur complete shape=%s device=%s op_elapsed=%.3fs total_elapsed=%.3fs",
+                     detailer_trace, tuple(noise_mask.shape), noise_mask.device,
+                     operation_end - operation_start, operation_end - detailer_start)
+        operation_start = time.perf_counter()
         noise_mask = noise_mask.squeeze(3)
-        logging.info("[Impact Pack] enhance_detail[%s] noise mask squeeze complete shape=%s elapsed=%.3fs",
-                     detailer_trace, tuple(noise_mask.shape), time.perf_counter() - detailer_start)
+        operation_end = time.perf_counter()
+        logging.info("[Impact Pack] enhance_detail[%s] noise mask squeeze complete shape=%s op_elapsed=%.3fs total_elapsed=%.3fs",
+                     detailer_trace, tuple(noise_mask.shape), operation_end - operation_start, operation_end - detailer_start)
 
         if noise_mask_feather > 0 and 'denoise_mask_function' not in model.model_options:
             logging.info("[Impact Pack] enhance_detail[%s] differential diffusion apply start", detailer_trace)
+            operation_start = time.perf_counter()
             model = utils.apply_differential_diffusion(model)
-            logging.info("[Impact Pack] enhance_detail[%s] differential diffusion apply complete elapsed=%.3fs",
-                         detailer_trace, time.perf_counter() - detailer_start)
+            operation_end = time.perf_counter()
+            logging.info("[Impact Pack] enhance_detail[%s] differential diffusion apply complete op_elapsed=%.3fs total_elapsed=%.3fs",
+                         detailer_trace, operation_end - operation_start, operation_end - detailer_start)
 
     if wildcard_opt is not None and wildcard_opt != "":
         logging.info("[Impact Pack] enhance_detail[%s] wildcard/LoRA processing start", detailer_trace)
+        operation_start = time.perf_counter()
         model, _, wildcard_positive = wildcards.process_with_loras(wildcard_opt, model, clip)
-        logging.info("[Impact Pack] enhance_detail[%s] wildcard/LoRA processing complete elapsed=%.3fs",
-                     detailer_trace, time.perf_counter() - detailer_start)
+        operation_end = time.perf_counter()
+        logging.info("[Impact Pack] enhance_detail[%s] wildcard/LoRA processing complete op_elapsed=%.3fs total_elapsed=%.3fs",
+                     detailer_trace, operation_end - operation_start, operation_end - detailer_start)
 
         if wildcard_opt_concat_mode == "concat":
             positive = nodes.ConditioningConcat().concat(positive, wildcard_positive)[0]
@@ -371,13 +380,15 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                 del positive[0][1]['pooled_output']
 
     logging.info("[Impact Pack] enhance_detail[%s] geometry start", detailer_trace)
+    operation_start = time.perf_counter()
     h = image.shape[1]
     w = image.shape[2]
 
     bbox_h = bbox[3] - bbox[1]
     bbox_w = bbox[2] - bbox[0]
-    logging.info("[Impact Pack] enhance_detail[%s] geometry complete crop=(%s, %s) bbox=(%s, %s) elapsed=%.3fs",
-                 detailer_trace, w, h, bbox_w, bbox_h, time.perf_counter() - detailer_start)
+    operation_end = time.perf_counter()
+    logging.info("[Impact Pack] enhance_detail[%s] geometry complete crop=(%s, %s) bbox=(%s, %s) op_elapsed=%.3fs total_elapsed=%.3fs",
+                 detailer_trace, w, h, bbox_w, bbox_h, operation_end - operation_start, operation_end - detailer_start)
 
     # Skip processing if the detected bbox is already larger than the guide_size
     if not force_inpaint and bbox_h >= guide_size and bbox_w >= guide_size:

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -267,7 +267,7 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                    refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None,
                    refiner_negative=None, control_net_wrapper=None, cycle=1,
                    inpaint_model=False, noise_mask_feather=0, scheduler_func=None,
-                   vae_tiled_encode=False, vae_tiled_decode=False):
+                   vae_tiled_encode=False, vae_tiled_decode=False, auto_vae_tiled_encode=False):
 
     if noise_mask is not None:
         noise_mask = utils.tensor_gaussian_blur_mask(noise_mask, noise_mask_feather)
@@ -366,7 +366,7 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                 upscaled_image,
                 vae,
                 vae_tiled_encode=vae_tiled_encode,
-                auto_vae_tiled_encode=True,
+                auto_vae_tiled_encode=auto_vae_tiled_encode,
             )
             if noise_mask is not None:
                 latent_image['noise_mask'] = noise_mask

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -60,11 +60,13 @@ ADDITIONAL_SCHEDULERS = ['AYS SDXL', 'AYS SD1', 'AYS SVD', 'GITS[coeff=1.2]', 'L
 
 
 class _ImpactTiledEncodeProxyVAE:
-    def __init__(self, vae):
+    def __init__(self, vae, tile_size=0, overlap=0):
         self._vae = vae
+        self._tile_size = tile_size
+        self._overlap = overlap
 
     def encode(self, pixels):
-        tile_size, overlap = utils.get_vae_tiled_encode_settings(pixels)
+        tile_size, overlap = utils.get_vae_tiled_encode_settings(pixels, tile_size=self._tile_size, overlap=self._overlap)
         return self._vae.encode_tiled(pixels, tile_x=tile_size, tile_y=tile_size, overlap=overlap)
 
     def __getattr__(self, name):
@@ -267,7 +269,8 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                    refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None,
                    refiner_negative=None, control_net_wrapper=None, cycle=1,
                    inpaint_model=False, noise_mask_feather=0, scheduler_func=None,
-                   vae_tiled_encode=False, vae_tiled_decode=False, auto_vae_tiled_encode=False):
+                   vae_tiled_encode=False, vae_tiled_decode=False, auto_vae_tiled_encode=False,
+                   vae_tile_size=0, vae_tile_overlap=0):
 
     if noise_mask is not None:
         noise_mask = utils.tensor_gaussian_blur_mask(noise_mask, noise_mask_feather)
@@ -355,7 +358,7 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
     if detailer_hook is None or not detailer_hook.get_skip_sampling():
         if noise_mask is not None and inpaint_model:
             imc_encode = nodes.InpaintModelConditioning().encode
-            imc_vae = _ImpactTiledEncodeProxyVAE(vae) if vae_tiled_encode else vae
+            imc_vae = _ImpactTiledEncodeProxyVAE(vae, tile_size=vae_tile_size, overlap=vae_tile_overlap) if vae_tiled_encode else vae
             if 'noise_mask' in inspect.signature(imc_encode).parameters:
                 positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, imc_vae, mask=noise_mask, noise_mask=True)
             else:
@@ -367,6 +370,8 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                 vae,
                 vae_tiled_encode=vae_tiled_encode,
                 auto_vae_tiled_encode=auto_vae_tiled_encode,
+                tile_size=vae_tile_size,
+                overlap=vae_tile_overlap,
             )
             if noise_mask is not None:
                 latent_image['noise_mask'] = noise_mask
@@ -408,8 +413,18 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
         # non-latent downscale - latent downscale cause bad quality
         start = time.time()
         if vae_tiled_decode:
-            (refined_image,) = nodes.VAEDecodeTiled().decode(vae, refined_latent, 512) # using default settings
-            logging.info(f"[Impact Pack] vae decoded (tiled) in {time.time() - start:.1f}s")
+            decode_tile_size, decode_overlap = utils.get_vae_tiled_encode_settings(
+                upscaled_image,
+                tile_size=vae_tile_size,
+                overlap=vae_tile_overlap,
+            )
+            decoder = nodes.VAEDecodeTiled()
+            if 'overlap' in inspect.signature(decoder.decode).parameters:
+                (refined_image,) = decoder.decode(vae, refined_latent, decode_tile_size, overlap=decode_overlap)
+            else:
+                logging.warning("[Impact Pack] Your ComfyUI is outdated.")
+                (refined_image,) = decoder.decode(vae, refined_latent, decode_tile_size)
+            logging.info(f"[Impact Pack] vae decoded (tiled {decode_tile_size}/{decode_overlap}) in {time.time() - start:.1f}s")
         else:
             try:
                 refined_image = vae.decode(refined_latent['samples'])

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -61,8 +61,9 @@ ADDITIONAL_SCHEDULERS = ['AYS SDXL', 'AYS SD1', 'AYS SVD', 'GITS[coeff=1.2]', 'L
 
 def _impact_is_wsl():
     try:
-        return "microsoft" in os.uname().release.lower() or "wsl" in os.uname().release.lower()
-    except Exception:
+        release = os.uname().release.lower()
+        return "microsoft" in release or "wsl" in release
+    except (AttributeError, OSError):
         return False
 
 
@@ -905,15 +906,15 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
     else:
         sam_obj = sam.sam_wrapper
 
-    logging.info(f"[Impact Pack] SAM mask start: segs={len(segs[1])} hint={detection_hint} dilation={dilation} bbox_expansion={bbox_expansion}")
+    logging.info("[Impact Pack] SAM mask start: segs=%d hint=%s dilation=%s bbox_expansion=%s", len(segs[1]), detection_hint, dilation, bbox_expansion)
     logging.info("[Impact Pack] SAM prepare_device start")
     sam_obj.prepare_device()
     logging.info("[Impact Pack] SAM prepare_device complete")
 
     try:
-        logging.info(f"[Impact Pack] SAM image conversion start shape={tuple(image.shape)} device={image.device}")
+        logging.info("[Impact Pack] SAM image conversion start shape=%s device=%s", tuple(image.shape), image.device)
         image = np.clip(255. * image.detach().cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
-        logging.info(f"[Impact Pack] SAM image conversion complete shape={image.shape}")
+        logging.info("[Impact Pack] SAM image conversion complete shape=%s", image.shape)
 
         total_masks = []
 
@@ -936,9 +937,9 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
                 else:
                     plabs.append(1)
 
-            logging.info(f"[Impact Pack] SAM predict mask-points start points={len(points)}")
+            logging.info("[Impact Pack] SAM predict mask-points start points=%d", len(points))
             detected_masks = sam_obj.predict(image, points, plabs, None, threshold)
-            logging.info(f"[Impact Pack] SAM predict mask-points complete masks={len(detected_masks)}")
+            logging.info("[Impact Pack] SAM predict mask-points complete masks=%d", len(detected_masks))
             total_masks += detected_masks
 
         else:
@@ -1007,18 +1008,15 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
                     points += npoints
                     plabs += nplabs
 
-                logging.info(
-                    f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} start "
-                    f"points={len(points)} bbox={dilated_bbox}"
-                )
+                logging.info("[Impact Pack] SAM predict segment %d/%d start points=%d bbox=%s", i + 1, len(segs), len(points), dilated_bbox)
                 detected_masks = sam_obj.predict(image, points, plabs, dilated_bbox, threshold)
-                logging.info(f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} complete masks={len(detected_masks)}")
+                logging.info("[Impact Pack] SAM predict segment %d/%d complete masks=%d", i + 1, len(segs), len(detected_masks))
                 total_masks += detected_masks
 
         # merge every collected masks
-        logging.info(f"[Impact Pack] SAM combine masks start count={len(total_masks)}")
+        logging.info("[Impact Pack] SAM combine masks start count=%d", len(total_masks))
         mask = utils.combine_masks2(total_masks)
-        logging.info(f"[Impact Pack] SAM combine masks complete shape={None if mask is None else tuple(mask.shape)}")
+        logging.info("[Impact Pack] SAM combine masks complete shape=%s", None if mask is None else tuple(mask.shape))
 
     finally:
         logging.info("[Impact Pack] SAM release_device start")
@@ -1026,11 +1024,11 @@ def make_sam_mask(sam, segs, image, detection_hint, dilation,
         logging.info("[Impact Pack] SAM release_device complete")
 
     if mask is not None:
-        logging.info(f"[Impact Pack] SAM postprocess start shape={tuple(mask.shape)}")
+        logging.info("[Impact Pack] SAM postprocess start shape=%s", tuple(mask.shape))
         mask = mask.float()
         mask = utils.dilate_mask(mask.cpu().numpy(), dilation)
         mask = torch.from_numpy(mask)
-        logging.info(f"[Impact Pack] SAM postprocess complete shape={tuple(mask.shape)}")
+        logging.info("[Impact Pack] SAM postprocess complete shape=%s", tuple(mask.shape))
     else:
         size = image.shape[0], image.shape[1]
         mask = torch.zeros(size, dtype=torch.float32, device="cpu")  # empty mask
@@ -1193,15 +1191,15 @@ def make_sam_mask_segmented(sam, segs, image, detection_hint, dilation,
         raise Exception("[Impact Pack] Invalid SAMLoader is connected. Make sure 'SAMLoader (Impact)'.")
 
     sam_obj = sam.sam_wrapper
-    logging.info(f"[Impact Pack] SAM mask start: segs={len(segs[1])} hint={detection_hint} dilation={dilation} bbox_expansion={bbox_expansion}")
-    logging.info("[Impact Pack] SAM prepare_device start")
+    logging.info("[Impact Pack] SAM segmented mask start: segs=%d hint=%s dilation=%s bbox_expansion=%s", len(segs[1]), detection_hint, dilation, bbox_expansion)
+    logging.info("[Impact Pack] SAM segmented prepare_device start")
     sam_obj.prepare_device()
-    logging.info("[Impact Pack] SAM prepare_device complete")
+    logging.info("[Impact Pack] SAM segmented prepare_device complete")
 
     try:
-        logging.info(f"[Impact Pack] SAM image conversion start shape={tuple(image.shape)} device={image.device}")
+        logging.info("[Impact Pack] SAM segmented image conversion start shape=%s device=%s", tuple(image.shape), image.device)
         image = np.clip(255. * image.detach().cpu().numpy().squeeze(), 0, 255).astype(np.uint8)
-        logging.info(f"[Impact Pack] SAM image conversion complete shape={image.shape}")
+        logging.info("[Impact Pack] SAM segmented image conversion complete shape=%s", image.shape)
 
         total_masks = []
 
@@ -1224,9 +1222,9 @@ def make_sam_mask_segmented(sam, segs, image, detection_hint, dilation,
                 else:
                     plabs.append(1)
 
-            logging.info(f"[Impact Pack] SAM predict mask-points start points={len(points)}")
+            logging.info("[Impact Pack] SAM segmented predict mask-points start points=%d", len(points))
             detected_masks = sam_obj.predict(image, points, plabs, None, threshold)
-            logging.info(f"[Impact Pack] SAM predict mask-points complete masks={len(detected_masks)}")
+            logging.info("[Impact Pack] SAM segmented predict mask-points complete masks=%d", len(detected_masks))
             total_masks += detected_masks
 
         else:
@@ -1244,33 +1242,30 @@ def make_sam_mask_segmented(sam, segs, image, detection_hint, dilation,
                                                          mask_hint_threshold, use_small_negative,
                                                          mask_hint_use_negative)
 
-                logging.info(
-                    f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} start "
-                    f"points={len(points)} bbox={dilated_bbox}"
-                )
+                logging.info("[Impact Pack] SAM segmented predict segment %d/%d start points=%d bbox=%s", i + 1, len(segs), len(points), dilated_bbox)
                 detected_masks = sam_obj.predict(image, points, plabs, dilated_bbox, threshold)
-                logging.info(f"[Impact Pack] SAM predict segment {i + 1}/{len(segs)} complete masks={len(detected_masks)}")
+                logging.info("[Impact Pack] SAM segmented predict segment %d/%d complete masks=%d", i + 1, len(segs), len(detected_masks))
 
                 total_masks += detected_masks
 
         # merge every collected masks
-        logging.info(f"[Impact Pack] SAM combine masks start count={len(total_masks)}")
+        logging.info("[Impact Pack] SAM segmented combine masks start count=%d", len(total_masks))
         mask = utils.combine_masks2(total_masks)
-        logging.info(f"[Impact Pack] SAM combine masks complete shape={None if mask is None else tuple(mask.shape)}")
+        logging.info("[Impact Pack] SAM segmented combine masks complete shape=%s", None if mask is None else tuple(mask.shape))
 
     finally:
-        logging.info("[Impact Pack] SAM release_device start")
+        logging.info("[Impact Pack] SAM segmented release_device start")
         sam_obj.release_device()
-        logging.info("[Impact Pack] SAM release_device complete")
+        logging.info("[Impact Pack] SAM segmented release_device complete")
 
     mask_working_device = torch.device("cpu")
 
     if mask is not None:
-        logging.info(f"[Impact Pack] SAM postprocess start shape={tuple(mask.shape)}")
+        logging.info("[Impact Pack] SAM segmented postprocess start shape=%s", tuple(mask.shape))
         mask = mask.float()
         mask = utils.dilate_mask(mask.cpu().numpy(), dilation)
         mask = torch.from_numpy(mask)
-        logging.info(f"[Impact Pack] SAM postprocess complete shape={tuple(mask.shape)}")
+        logging.info("[Impact Pack] SAM segmented postprocess complete shape=%s", tuple(mask.shape))
         mask = mask.to(device=mask_working_device)
     else:
         # Extracting batch, height and width

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -362,7 +362,12 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                 logging.warning("[Impact Pack] ComfyUI is an outdated version.")
                 positive, negative, latent_image = imc_encode(positive, negative, upscaled_image, imc_vae, noise_mask)
         else:
-            latent_image = utils.to_latent_image(upscaled_image, vae, vae_tiled_encode=vae_tiled_encode)
+            latent_image = utils.to_latent_image(
+                upscaled_image,
+                vae,
+                vae_tiled_encode=vae_tiled_encode,
+                auto_vae_tiled_encode=True,
+            )
             if noise_mask is not None:
                 latent_image['noise_mask'] = noise_mask
 

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -331,35 +331,11 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
             logging.info(f"Detailer: segment skip [zero size={new_w, new_h}]")
             return None, None
     else:
-        if new_w == 0 or new_h == 0:
-            logging.info("Detailer: force inpaint [zero computed size; using original crop size]")
+        if upscale <= 1.0 or new_w == 0 or new_h == 0:
+            logging.info("Detailer: force inpaint")
             upscale = 1.0
             new_w = w
             new_h = h
-        elif upscale <= 1.0:
-            # Force-inpaint means "do not skip this segment"; it should not silently
-            # bypass the existing guide_size/max_size working-resolution controls.
-            #
-            # The old behavior reset upscale to 1.0 whenever the crop was already
-            # larger than guide_size. For large person/full-frame detections this
-            # pushed FaceDetailer into full-frame VAE encode/decode, e.g. a
-            # 1900x2732 crop, which is both unnecessary for a detailer pass and a
-            # WSL/CUDA/model-loading wedge trigger.
-            logging.info(
-                "Detailer: force inpaint [keeping capped working size] "
-                f"crop={(w, h)} -> working={(new_w, new_h)} upscale={upscale}"
-            )
-
-    if max_size > 0 and (new_w > max_size or new_h > max_size):
-        old_new_w, old_new_h = new_w, new_h
-        cap_scale = max_size / max(new_w, new_h)
-        upscale *= cap_scale
-        new_w = max(1, int(w * upscale))
-        new_h = max(1, int(h * upscale))
-        logging.info(
-            "Detailer: max_size cap "
-            f"{(old_new_w, old_new_h)} -> {(new_w, new_h)} max_size={max_size}"
-        )
 
     if detailer_hook is not None:
         new_w, new_h = detailer_hook.touch_scaled_size(new_w, new_h)

--- a/modules/impact/core.py
+++ b/modules/impact/core.py
@@ -330,15 +330,35 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
                    vae_tiled_encode=False, vae_tiled_decode=False, auto_vae_tiled_encode=False,
                    vae_tile_size=0, vae_tile_overlap=0):
 
+    detailer_trace = format(id(image) & 0xfffffff, "x")
+    detailer_start = time.perf_counter()
+    logging.info(
+        "[Impact Pack] enhance_detail[%s] enter "
+        f"image={tuple(image.shape)} noise_mask={None if noise_mask is None else tuple(noise_mask.shape)} "
+        f"noise_mask_feather={noise_mask_feather} wildcard={bool(wildcard_opt)} force_inpaint={force_inpaint}",
+        detailer_trace
+    )
+
     if noise_mask is not None:
+        logging.info("[Impact Pack] enhance_detail[%s] noise mask blur start", detailer_trace)
         noise_mask = utils.tensor_gaussian_blur_mask(noise_mask, noise_mask_feather)
+        logging.info("[Impact Pack] enhance_detail[%s] noise mask blur complete shape=%s device=%s elapsed=%.3fs",
+                     detailer_trace, tuple(noise_mask.shape), noise_mask.device, time.perf_counter() - detailer_start)
         noise_mask = noise_mask.squeeze(3)
+        logging.info("[Impact Pack] enhance_detail[%s] noise mask squeeze complete shape=%s elapsed=%.3fs",
+                     detailer_trace, tuple(noise_mask.shape), time.perf_counter() - detailer_start)
 
         if noise_mask_feather > 0 and 'denoise_mask_function' not in model.model_options:
+            logging.info("[Impact Pack] enhance_detail[%s] differential diffusion apply start", detailer_trace)
             model = utils.apply_differential_diffusion(model)
+            logging.info("[Impact Pack] enhance_detail[%s] differential diffusion apply complete elapsed=%.3fs",
+                         detailer_trace, time.perf_counter() - detailer_start)
 
     if wildcard_opt is not None and wildcard_opt != "":
+        logging.info("[Impact Pack] enhance_detail[%s] wildcard/LoRA processing start", detailer_trace)
         model, _, wildcard_positive = wildcards.process_with_loras(wildcard_opt, model, clip)
+        logging.info("[Impact Pack] enhance_detail[%s] wildcard/LoRA processing complete elapsed=%.3fs",
+                     detailer_trace, time.perf_counter() - detailer_start)
 
         if wildcard_opt_concat_mode == "concat":
             positive = nodes.ConditioningConcat().concat(positive, wildcard_positive)[0]
@@ -350,11 +370,14 @@ def enhance_detail(image, model, clip, vae, guide_size, guide_size_for_bbox, max
             elif 'pooled_output' in positive[0][1]:
                 del positive[0][1]['pooled_output']
 
+    logging.info("[Impact Pack] enhance_detail[%s] geometry start", detailer_trace)
     h = image.shape[1]
     w = image.shape[2]
 
     bbox_h = bbox[3] - bbox[1]
     bbox_w = bbox[2] - bbox[0]
+    logging.info("[Impact Pack] enhance_detail[%s] geometry complete crop=(%s, %s) bbox=(%s, %s) elapsed=%.3fs",
+                 detailer_trace, w, h, bbox_w, bbox_h, time.perf_counter() - detailer_start)
 
     # Skip processing if the detected bbox is already larger than the guide_size
     if not force_inpaint and bbox_h >= guide_size and bbox_w >= guide_size:

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -573,7 +573,8 @@ class DetailerForEachAutoRetry:
                   positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard_opt=None, detailer_hook=None,
                   refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None,
                   cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
-                  post_detail_shrink=False, post_detail_shrink_scale=0.995, max_retries=1, auto_vae_tiled_encode=False):
+                  post_detail_shrink=False, post_detail_shrink_scale=0.995, max_retries=1, auto_vae_tiled_encode=False,
+                  vae_tile_size=0, vae_tile_overlap=0):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -684,7 +685,8 @@ class DetailerForEachAutoRetry:
                                                                     refiner_negative=refiner_negative, control_net_wrapper=seg.control_net_wrapper,
                                                                     cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                                                     scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
-                                                                    vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode)
+                                                                    vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode,
+                                                                    vae_tile_size=vae_tile_size, vae_tile_overlap=vae_tile_overlap)
 
                     if detailer_hook is None or not detailer_hook.should_retry_patch(enhanced_image):
                         break
@@ -892,6 +894,8 @@ class FaceDetailer:
                     "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
                     "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                     "force_adaptive_tiled_encode": ("BOOLEAN", {"default": True, "label_on": "enabled", "label_off": "disabled", "tooltip": "Keeps FaceDetailer on the adaptive tiled VAE encode path (including 512/64). Disable to allow fallback to the legacy non-tiled path when applicable."}),
+                    "tile_size": ("INT", {"default": 0, "min": 0, "max": 4096, "step": 16, "tooltip": "FaceDetailer VAE tiled encode/decode tile size. 0 = automatic size based on crop resolution."}),
+                    "tile_overlap": ("INT", {"default": 0, "min": 0, "max": 1024, "step": 8, "tooltip": "FaceDetailer VAE tiled encode/decode overlap. 0 = automatic overlap based on the resolved tile size."}),
                 }}
 
     RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "MASK", "DETAILER_PIPE", "IMAGE")
@@ -912,7 +916,8 @@ class FaceDetailer:
                      bbox_detector, segm_detector=None, sam_model_opt=None, wildcard_opt=None, detailer_hook=None,
                      refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None, cycle=1,
                      inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
-                     post_detail_shrink=False, post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True):
+                     post_detail_shrink=False, post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True,
+                     tile_size=0, tile_overlap=0):
 
         # make default prompt as 'face' if empty prompt for CLIPSeg
         bbox_detector.setAux('face')
@@ -948,7 +953,8 @@ class FaceDetailer:
                                           cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                           scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
                                           post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
-                                          auto_vae_tiled_encode=force_adaptive_tiled_encode)
+                                          auto_vae_tiled_encode=force_adaptive_tiled_encode,
+                                          vae_tile_size=tile_size, vae_tile_overlap=tile_overlap)
             mask_segs = new_segs
         else:
             enhanced_img = image
@@ -977,7 +983,7 @@ class FaceDetailer:
              sam_mask_hint_use_negative, drop_size, bbox_detector, wildcard, cycle=1,
              sam_model_opt=None, segm_detector_opt=None, detailer_hook=None, inpaint_model=False, noise_mask_feather=0,
              scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, post_detail_shrink=False,
-             post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True):
+             post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True, tile_size=0, tile_overlap=0):
 
         result_img = None
         result_mask = None
@@ -998,7 +1004,7 @@ class FaceDetailer:
                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
                 tiled_encode=tiled_encode, tiled_decode=tiled_decode,
                 post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
-                force_adaptive_tiled_encode=force_adaptive_tiled_encode)
+                force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
 
             result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
             result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
@@ -1795,6 +1801,8 @@ class FaceDetailerPipe:
                     "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
                     "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                     "force_adaptive_tiled_encode": ("BOOLEAN", {"default": True, "label_on": "enabled", "label_off": "disabled", "tooltip": "Keeps FaceDetailer on the adaptive tiled VAE encode path (including 512/64). Disable to allow fallback to the legacy non-tiled path when applicable."}),
+                    "tile_size": ("INT", {"default": 0, "min": 0, "max": 4096, "step": 16, "tooltip": "FaceDetailer VAE tiled encode/decode tile size. 0 = automatic size based on crop resolution."}),
+                    "tile_overlap": ("INT", {"default": 0, "min": 0, "max": 1024, "step": 8, "tooltip": "FaceDetailer VAE tiled encode/decode overlap. 0 = automatic overlap based on the resolved tile size."}),
                    }
                 }
 
@@ -1813,7 +1821,7 @@ class FaceDetailerPipe:
              sam_mask_hint_threshold, sam_mask_hint_use_negative, drop_size, refiner_ratio=None,
              cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
              tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995,
-             force_adaptive_tiled_encode=True):
+             force_adaptive_tiled_encode=True, tile_size=0, tile_overlap=0):
 
         result_img = None
         result_mask = None
@@ -1839,7 +1847,7 @@ class FaceDetailerPipe:
                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
                 tiled_encode=tiled_encode, tiled_decode=tiled_decode,
                 post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
-                force_adaptive_tiled_encode=force_adaptive_tiled_encode)
+                force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
 
             result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
             result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -86,6 +86,91 @@ def _impact_cpu_detached(tensor):
     return tensor
 
 
+def _impact_repair_detailer_tensor(tensor, *, fallback=None, label="tensor", clamp_image=False):
+    """Return a finite CPU tensor for detailer paste/alpha boundaries.
+
+    Detailer samplers/VAEs can occasionally return NaN/Inf pixels. PyTorch
+    blend arithmetic propagates those values even where a mask is zero, which
+    can poison the whole downstream IMAGE tensor. Non-finite enhanced pixels are
+    replaced from the original crop when available; remaining invalid values are
+    clamped into the IMAGE range.
+    """
+    if tensor is None or not torch.is_tensor(tensor):
+        return tensor
+
+    repaired = tensor.detach().cpu()
+    finite = torch.isfinite(repaired)
+    needs_repair = not bool(finite.all().item())
+
+    if needs_repair:
+        bad = int((~finite).sum().item())
+        total = int(repaired.numel())
+        logging.warning(
+            "[Impact Pack] %s contained non-finite values; repairing %d/%d components before paste",
+            label,
+            bad,
+            total,
+        )
+
+        if fallback is not None and torch.is_tensor(fallback):
+            fallback_tensor = fallback.detach().cpu()
+            if fallback_tensor.shape != repaired.shape:
+                try:
+                    fallback_tensor = utils.tensor_resize_for_detailer_output(
+                        fallback_tensor, *utils.tensor_get_size(repaired)
+                    )
+                except Exception:
+                    logging.warning(
+                        "[Impact Pack] %s fallback resize failed during non-finite repair",
+                        label,
+                        exc_info=True,
+                    )
+                    fallback_tensor = None
+        else:
+            fallback_tensor = None
+
+        if fallback_tensor is not None and fallback_tensor.shape == repaired.shape:
+            fallback_tensor = fallback_tensor.to(dtype=repaired.dtype)
+            fallback_tensor = torch.nan_to_num(
+                fallback_tensor, nan=0.0, posinf=1.0, neginf=0.0
+            )
+            if clamp_image:
+                fallback_tensor = fallback_tensor.clamp(0.0, 1.0)
+
+            repaired = torch.where(
+                finite,
+                torch.nan_to_num(repaired, nan=0.0, posinf=1.0, neginf=0.0),
+                fallback_tensor,
+            )
+        else:
+            repaired = torch.nan_to_num(repaired, nan=0.0, posinf=1.0, neginf=0.0)
+
+    if clamp_image:
+        repaired = repaired.clamp(0.0, 1.0)
+
+    return repaired
+
+
+def _impact_repair_detailer_mask(mask, *, label="mask"):
+    if mask is None or not torch.is_tensor(mask):
+        return mask
+
+    repaired = mask.detach().cpu()
+    finite = torch.isfinite(repaired)
+    if not bool(finite.all().item()):
+        bad = int((~finite).sum().item())
+        total = int(repaired.numel())
+        logging.warning(
+            "[Impact Pack] %s contained non-finite values; clearing %d/%d mask components before paste",
+            label,
+            bad,
+            total,
+        )
+        repaired = torch.nan_to_num(repaired, nan=0.0, posinf=0.0, neginf=0.0)
+
+    return repaired
+
+
 def _impact_inset_mask_region(data, offset_x, offset_y, inner_w, inner_h):
     """Zero mask values outside the requested inner rectangle."""
     if data is None:
@@ -590,8 +675,16 @@ class DetailerForEach:
                 # don't latent composite-> converting to latent caused poor quality
                 # use image paste
                 image = image.detach().cpu()
-                enhanced_image = enhanced_image.detach().cpu()
-                mask = mask.detach().cpu()
+                enhanced_image = _impact_repair_detailer_tensor(
+                    enhanced_image,
+                    fallback=orig_cropped_image,
+                    label=f"Detailer segment {i + 1}/{len(ordered_segs)} enhanced image",
+                    clamp_image=True,
+                )
+                mask = _impact_repair_detailer_mask(
+                    mask,
+                    label=f"Detailer segment {i + 1}/{len(ordered_segs)} paste mask",
+                )
                 logging.info("[Impact Pack] Detailer segment %d/%d paste start region=%s enhanced=%s mask=%s", i + 1, len(ordered_segs), seg.crop_region, tuple(enhanced_image.shape), tuple(mask.shape))
                 utils.tensor_paste(image, enhanced_image, (seg.crop_region[0], seg.crop_region[1]), mask)  # this code affecting to `cropped_image`.
                 logging.info("[Impact Pack] Detailer segment %d/%d paste complete", i + 1, len(ordered_segs))
@@ -855,8 +948,16 @@ class DetailerForEachAutoRetry:
                 # don't latent composite-> converting to latent caused poor quality
                 # use image paste
                 image = image.detach().cpu()
-                enhanced_image = enhanced_image.detach().cpu()
-                mask = mask.detach().cpu()
+                enhanced_image = _impact_repair_detailer_tensor(
+                    enhanced_image,
+                    fallback=orig_cropped_image,
+                    label=f"Detailer segment {i + 1}/{len(ordered_segs)} enhanced image",
+                    clamp_image=True,
+                )
+                mask = _impact_repair_detailer_mask(
+                    mask,
+                    label=f"Detailer segment {i + 1}/{len(ordered_segs)} paste mask",
+                )
                 logging.info("[Impact Pack] Detailer segment %d/%d paste start region=%s enhanced=%s mask=%s", i + 1, len(ordered_segs), seg.crop_region, tuple(enhanced_image.shape), tuple(mask.shape))
                 utils.tensor_paste(image, enhanced_image, (seg.crop_region[0], seg.crop_region[1]), mask)  # this code affecting to `cropped_image`.
                 logging.info("[Impact Pack] Detailer segment %d/%d paste complete", i + 1, len(ordered_segs))

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -341,7 +341,7 @@ class DetailerForEach:
                   positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard_opt=None, detailer_hook=None,
                   refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None,
                   cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
-                  post_detail_shrink=False, post_detail_shrink_scale=0.995):
+                  post_detail_shrink=False, post_detail_shrink_scale=0.995, auto_vae_tiled_encode=False):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -446,7 +446,7 @@ class DetailerForEach:
                                                                 refiner_negative=refiner_negative, control_net_wrapper=seg.control_net_wrapper,
                                                                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                                                 scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
-                                                                vae_tiled_decode=tiled_decode)
+                                                                vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode)
             else:
                 enhanced_image = cropped_image
                 cnet_pils = None
@@ -573,7 +573,7 @@ class DetailerForEachAutoRetry:
                   positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard_opt=None, detailer_hook=None,
                   refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None,
                   cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
-                  post_detail_shrink=False, post_detail_shrink_scale=0.995, max_retries=1):
+                  post_detail_shrink=False, post_detail_shrink_scale=0.995, max_retries=1, auto_vae_tiled_encode=False):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -684,7 +684,7 @@ class DetailerForEachAutoRetry:
                                                                     refiner_negative=refiner_negative, control_net_wrapper=seg.control_net_wrapper,
                                                                     cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                                                     scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
-                                                                    vae_tiled_decode=tiled_decode)
+                                                                    vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode)
 
                     if detailer_hook is None or not detailer_hook.should_retry_patch(enhanced_image):
                         break
@@ -891,6 +891,7 @@ class FaceDetailer:
                     "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                     "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
                     "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
+                    "force_adaptive_tiled_encode": ("BOOLEAN", {"default": True, "label_on": "enabled", "label_off": "disabled", "tooltip": "Keeps FaceDetailer on the adaptive tiled VAE encode path (including 512/64). Disable to allow fallback to the legacy non-tiled path when applicable."}),
                 }}
 
     RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "MASK", "DETAILER_PIPE", "IMAGE")
@@ -911,7 +912,7 @@ class FaceDetailer:
                      bbox_detector, segm_detector=None, sam_model_opt=None, wildcard_opt=None, detailer_hook=None,
                      refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None, cycle=1,
                      inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
-                     post_detail_shrink=False, post_detail_shrink_scale=0.995):
+                     post_detail_shrink=False, post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True):
 
         # make default prompt as 'face' if empty prompt for CLIPSeg
         bbox_detector.setAux('face')
@@ -946,7 +947,8 @@ class FaceDetailer:
                                           refiner_negative=refiner_negative,
                                           cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                           scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
-                                          post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
+                                          post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
+                                          auto_vae_tiled_encode=force_adaptive_tiled_encode)
             mask_segs = new_segs
         else:
             enhanced_img = image
@@ -974,7 +976,8 @@ class FaceDetailer:
              sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
              sam_mask_hint_use_negative, drop_size, bbox_detector, wildcard, cycle=1,
              sam_model_opt=None, segm_detector_opt=None, detailer_hook=None, inpaint_model=False, noise_mask_feather=0,
-             scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
+             scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, post_detail_shrink=False,
+             post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True):
 
         result_img = None
         result_mask = None
@@ -994,7 +997,8 @@ class FaceDetailer:
                 sam_mask_hint_use_negative, drop_size, bbox_detector, segm_detector_opt, sam_model_opt, wildcard, detailer_hook,
                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
                 tiled_encode=tiled_encode, tiled_decode=tiled_decode,
-                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
+                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
+                force_adaptive_tiled_encode=force_adaptive_tiled_encode)
 
             result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
             result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
@@ -1790,6 +1794,7 @@ class FaceDetailerPipe:
                     "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                     "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
                     "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
+                    "force_adaptive_tiled_encode": ("BOOLEAN", {"default": True, "label_on": "enabled", "label_off": "disabled", "tooltip": "Keeps FaceDetailer on the adaptive tiled VAE encode path (including 512/64). Disable to allow fallback to the legacy non-tiled path when applicable."}),
                    }
                 }
 
@@ -1807,7 +1812,8 @@ class FaceDetailerPipe:
              sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion,
              sam_mask_hint_threshold, sam_mask_hint_use_negative, drop_size, refiner_ratio=None,
              cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
-             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
+             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995,
+             force_adaptive_tiled_encode=True):
 
         result_img = None
         result_mask = None
@@ -1832,7 +1838,8 @@ class FaceDetailerPipe:
                 refiner_clip=refiner_clip, refiner_positive=refiner_positive, refiner_negative=refiner_negative,
                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
                 tiled_encode=tiled_encode, tiled_decode=tiled_decode,
-                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
+                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
+                force_adaptive_tiled_encode=force_adaptive_tiled_encode)
 
             result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
             result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -708,16 +708,16 @@ class DetailerForEachAutoRetry:
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
-        logging.info("[Impact Pack] DetailerForEach enter image=%s segs=%d", tuple(image.shape), len(segs[1]))
+        logging.info("[Impact Pack] DetailerForEachAutoRetry enter image=%s segs=%d", tuple(image.shape), len(segs[1]))
         image = image.clone()
         enhanced_alpha_list = []
         enhanced_list = []
         cropped_list = []
         cnet_pil_list = []
 
-        logging.info("[Impact Pack] DetailerForEach segs_scale_match start")
+        logging.info("[Impact Pack] DetailerForEachAutoRetry segs_scale_match start")
         segs = core.segs_scale_match(segs, image.shape)
-        logging.info("[Impact Pack] DetailerForEach segs_scale_match complete segs=%d", len(segs[1]))
+        logging.info("[Impact Pack] DetailerForEachAutoRetry segs_scale_match complete segs=%d", len(segs[1]))
         new_segs = []
 
         wildcard_concat_mode = None

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -100,15 +100,6 @@ def _apply_post_detail_shrink(cropped_image, enhanced_image, paste_mask, cropped
 
     scale = max(0.01, min(1.0, scale))
 
-    # The default shrink value is 0.995. On large/detailer crops this causes an
-    # almost invisible resample of the finished patch, but it can lower apparent
-    # detail and has been observed to wedge right after "post_detail_shrink start".
-    # Treat near-identity shrink as a no-op. Users that need an actual shrink can
-    # still set a visibly smaller scale, e.g. <= 0.98.
-    if scale >= 0.99:
-        logging.info(f"Detailer: post-detail shrink skipped near-identity scale={scale:.4f}")
-        return cropped_image, enhanced_image, paste_mask, cropped_mask_base
-
     crop_w, crop_h = utils.tensor_get_size(enhanced_image)
     scaled_w = max(1, int(round(crop_w * scale)))
     scaled_h = max(1, int(round(crop_h * scale)))

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -48,23 +48,25 @@ warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is
 model_path = folder_paths.models_dir
 
 
-def _impact_detailer_cleanup(label=None, clear_cuda_cache=True):
+def _impact_detailer_cleanup(label=None, clear_cuda_cache=True, collect_python=True, synchronize=True):
     """Best-effort cleanup between FaceDetailer regions/frames.
 
     This deliberately avoids unloading models. It only releases Python garbage,
-    synchronizes pending CUDA work, and clears allocator cache when available.
-    That makes failures surface at the detailer boundary instead of later nodes
-    and reduces allocator churn for large batched/detailer workflows.
+    synchronizes pending CUDA work, and clears allocator cache when requested.
+    Frame-level callers can use a lighter synchronization-only boundary because
+    DetailerForEach already performs deep cleanup after each processed segment.
     """
-    gc.collect()
+    if collect_python:
+        gc.collect()
 
     if not torch.cuda.is_available():
         return
 
-    try:
-        torch.cuda.synchronize()
-    except Exception as e:
-        logging.warning(f"[Impact Pack] CUDA synchronize during FaceDetailer cleanup failed{f' ({label})' if label else ''}: {e}")
+    if synchronize:
+        try:
+            torch.cuda.synchronize()
+        except Exception as e:
+            logging.warning(f"[Impact Pack] CUDA synchronize during FaceDetailer cleanup failed{f' ({label})' if label else ''}: {e}")
 
     if not clear_cuda_cache:
         return
@@ -1122,6 +1124,7 @@ class FaceDetailer:
             logging.warning("[Impact Pack] WARN: FaceDetailer is not a node designed for video detailing. If you intend to perform video detailing, please use Detailer For AnimateDiff.")
 
         for i, single_image in enumerate(image):
+            frame_ok = False
             logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} start")
             enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
             try:
@@ -1141,10 +1144,19 @@ class FaceDetailer:
                 result_cropped_enhanced.extend(cropped_enhanced)
                 result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
                 result_cnet_images.extend(cnet_pil_list)
+                frame_ok = True
             finally:
                 del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
-                _impact_detailer_cleanup(f"FaceDetailer frame {i + 1}")
-                logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} complete")
+                logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} cleanup start")
+                _impact_detailer_cleanup(
+                    f"FaceDetailer frame {i + 1}",
+                    clear_cuda_cache=False,
+                    collect_python=False,
+                )
+                logging.info(
+                    f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} "
+                    f"{'complete' if frame_ok else 'failed'}"
+                )
 
         result_img = torch.cat(result_imgs, dim=0) if len(result_imgs) > 0 else image
         result_mask = torch.cat(result_masks, dim=0) if len(result_masks) > 0 else torch.zeros((len(image), image.shape[1], image.shape[2]), dtype=torch.float32)
@@ -1973,6 +1985,7 @@ class FaceDetailerPipe:
             refiner_model, refiner_clip, refiner_positive, refiner_negative = detailer_pipe
 
         for i, single_image in enumerate(image):
+            frame_ok = False
             logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} start")
             enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
             try:
@@ -1994,10 +2007,19 @@ class FaceDetailerPipe:
                 result_cropped_enhanced.extend(cropped_enhanced)
                 result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
                 result_cnet_images.extend(cnet_pil_list)
+                frame_ok = True
             finally:
                 del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
-                _impact_detailer_cleanup(f"FaceDetailerPipe frame {i + 1}")
-                logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} complete")
+                logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} cleanup start")
+                _impact_detailer_cleanup(
+                    f"FaceDetailerPipe frame {i + 1}",
+                    clear_cuda_cache=False,
+                    collect_python=False,
+                )
+                logging.info(
+                    f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} "
+                    f"{'complete' if frame_ok else 'failed'}"
+                )
 
         result_img = torch.cat(result_imgs, dim=0) if len(result_imgs) > 0 else image
         result_mask = torch.cat(result_masks, dim=0) if len(result_masks) > 0 else torch.zeros((len(image), image.shape[1], image.shape[2]), dtype=torch.float32)

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -473,6 +473,7 @@ class DetailerForEach:
 
             orig_cropped_image = cropped_image.clone()
             if not (isinstance(model, str) and model == "DUMMY"):
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} enhance_detail start crop={tuple(cropped_image.shape)}")
                 enhanced_image, cnet_pils = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
                                                                 seg.bbox, seg_seed, steps, cfg, sampler_name, scheduler,
                                                                 cropped_positive, cropped_negative, denoise, cropped_mask, force_inpaint,
@@ -485,10 +486,12 @@ class DetailerForEach:
                                                                 scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
                                                                 vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode,
                                                                 vae_tile_size=vae_tile_size, vae_tile_overlap=vae_tile_overlap)
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} enhance_detail returned shape={None if enhanced_image is None else tuple(enhanced_image.shape)}")
             else:
                 enhanced_image = cropped_image
                 cnet_pils = None
 
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} post_detail_shrink start")
             orig_cropped_image, enhanced_image, mask, cropped_mask_for_output = _apply_post_detail_shrink(
                     orig_cropped_image,
                     enhanced_image,
@@ -506,9 +509,12 @@ class DetailerForEach:
             if enhanced_image is not None:
                 # don't latent composite-> converting to latent caused poor quality
                 # use image paste
-                image = image.cpu()
-                enhanced_image = enhanced_image.cpu()
+                image = image.detach().cpu()
+                enhanced_image = enhanced_image.detach().cpu()
+                mask = mask.detach().cpu()
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste start region={seg.crop_region} enhanced={tuple(enhanced_image.shape)} mask={tuple(mask.shape)}")
                 utils.tensor_paste(image, enhanced_image, (seg.crop_region[0], seg.crop_region[1]), mask)  # this code affecting to `cropped_image`.
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste complete")
                 enhanced_list.append(enhanced_image)
 
                 if detailer_hook is not None:
@@ -516,13 +522,15 @@ class DetailerForEach:
 
             if enhanced_image is not None:
                 # Convert enhanced_pil_alpha to RGBA mode
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output start")
                 enhanced_image_alpha = utils.tensor_convert_rgba(enhanced_image)
                 new_seg_image = enhanced_image.numpy()  # alpha should not be applied to seg_image
 
                 # Apply the mask
-                mask = utils.tensor_resize(mask, *utils.tensor_get_size(enhanced_image))
+                mask = utils.tensor_resize_for_detailer_output(mask, *utils.tensor_get_size(enhanced_image))
                 utils.tensor_putalpha(enhanced_image_alpha, mask)
                 enhanced_alpha_list.append(enhanced_image_alpha)
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output complete")
             else:
                 new_seg_image = None
 
@@ -719,6 +727,7 @@ class DetailerForEachAutoRetry:
 
             if not (isinstance(model, str) and model == "DUMMY"):
                 for retry in range(max_retries):
+                    logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} retry {retry + 1}/{max_retries} enhance_detail start crop={tuple(cropped_image.shape)}")
                     enhanced_image, cnet_pils = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
                                                                     seg.bbox, seg_seed + retry, steps, cfg, sampler_name, scheduler,
                                                                     cropped_positive, cropped_negative, denoise, cropped_mask, force_inpaint,
@@ -731,6 +740,7 @@ class DetailerForEachAutoRetry:
                                                                     scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
                                                                     vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode,
                                                                     vae_tile_size=vae_tile_size, vae_tile_overlap=vae_tile_overlap)
+                    logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} retry {retry + 1}/{max_retries} enhance_detail returned shape={None if enhanced_image is None else tuple(enhanced_image.shape)}")
 
                     if detailer_hook is None or not detailer_hook.should_retry_patch(enhanced_image):
                         break
@@ -757,9 +767,12 @@ class DetailerForEachAutoRetry:
             if enhanced_image is not None:
                 # don't latent composite-> converting to latent caused poor quality
                 # use image paste
-                image = image.cpu()
-                enhanced_image = enhanced_image.cpu()
+                image = image.detach().cpu()
+                enhanced_image = enhanced_image.detach().cpu()
+                mask = mask.detach().cpu()
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste start region={seg.crop_region} enhanced={tuple(enhanced_image.shape)} mask={tuple(mask.shape)}")
                 utils.tensor_paste(image, enhanced_image, (seg.crop_region[0], seg.crop_region[1]), mask)  # this code affecting to `cropped_image`.
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste complete")
                 enhanced_list.append(enhanced_image)
 
                 if detailer_hook is not None:
@@ -767,13 +780,15 @@ class DetailerForEachAutoRetry:
 
             if enhanced_image is not None:
                 # Convert enhanced_pil_alpha to RGBA mode
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output start")
                 enhanced_image_alpha = utils.tensor_convert_rgba(enhanced_image)
                 new_seg_image = enhanced_image.numpy()  # alpha should not be applied to seg_image
 
                 # Apply the mask
-                mask = utils.tensor_resize(mask, *utils.tensor_get_size(enhanced_image))
+                mask = utils.tensor_resize_for_detailer_output(mask, *utils.tensor_get_size(enhanced_image))
                 utils.tensor_putalpha(enhanced_image_alpha, mask)
                 enhanced_alpha_list.append(enhanced_image_alpha)
+                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output complete")
             else:
                 new_seg_image = None
 

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -84,6 +84,52 @@ def _impact_cpu_detached(tensor):
     return tensor
 
 
+def _impact_inset_mask_region(data, offset_x, offset_y, inner_w, inner_h):
+    """Zero mask values outside the requested inner rectangle."""
+    if data is None:
+        return None
+
+    x0 = max(0, int(offset_x))
+    y0 = max(0, int(offset_y))
+    x1 = x0 + max(0, int(inner_w))
+    y1 = y0 + max(0, int(inner_h))
+
+    if torch.is_tensor(data):
+        out = torch.zeros_like(data)
+        if data.ndim == 4:
+            x1 = min(x1, data.shape[2])
+            y1 = min(y1, data.shape[1])
+            out[:, y0:y1, x0:x1, :] = data[:, y0:y1, x0:x1, :]
+        elif data.ndim == 3:
+            x1 = min(x1, data.shape[2])
+            y1 = min(y1, data.shape[1])
+            out[:, y0:y1, x0:x1] = data[:, y0:y1, x0:x1]
+        elif data.ndim == 2:
+            x1 = min(x1, data.shape[1])
+            y1 = min(y1, data.shape[0])
+            out[y0:y1, x0:x1] = data[y0:y1, x0:x1]
+        else:
+            raise ValueError(f"Unsupported mask ndim for inset: {data.ndim}")
+        return out
+
+    arr = np.asarray(data)
+    out = np.zeros_like(arr)
+    if arr.ndim == 4:
+        x1 = min(x1, arr.shape[2])
+        y1 = min(y1, arr.shape[1])
+        out[:, y0:y1, x0:x1, :] = arr[:, y0:y1, x0:x1, :]
+    elif arr.ndim == 3:
+        x1 = min(x1, arr.shape[2])
+        y1 = min(y1, arr.shape[1])
+        out[:, y0:y1, x0:x1] = arr[:, y0:y1, x0:x1]
+    elif arr.ndim == 2:
+        x1 = min(x1, arr.shape[1])
+        y1 = min(y1, arr.shape[0])
+        out[y0:y1, x0:x1] = arr[y0:y1, x0:x1]
+    else:
+        raise ValueError(f"Unsupported mask ndim for inset: {arr.ndim}")
+    return out
+
 # folder_paths.supported_pt_extensions
 utils.add_folder_path_and_extensions("sams", [os.path.join(model_path, "sams")], folder_paths.supported_pt_extensions)
 utils.add_folder_path_and_extensions("onnx", [os.path.join(model_path, "onnx")], {'.onnx'})
@@ -116,6 +162,28 @@ def _apply_post_detail_shrink(cropped_image, enhanced_image, paste_mask, cropped
     offset_y = int(round(bbox_cy - bbox_cy * scale))
     offset_x = min(max(offset_x, 0), max(crop_w - scaled_w, 0))
     offset_y = min(max(offset_y, 0), max(crop_h - scaled_h, 0))
+
+    shrink_delta_w = crop_w - scaled_w
+    shrink_delta_h = crop_h - scaled_h
+
+    if shrink_delta_w <= 16 and shrink_delta_h <= 16:
+        logging.info(
+            "Detailer: post-detail shrink using mask-only inset "
+            f"scale={scale:.4f} offset=({offset_x}, {offset_y}) "
+            f"size=({crop_w}, {crop_h})->({scaled_w}, {scaled_h})"
+        )
+        shrunken_paste_mask = _impact_inset_mask_region(
+            paste_mask, offset_x, offset_y, scaled_w, scaled_h
+        )
+        if torch.is_tensor(shrunken_paste_mask):
+            shrunken_paste_mask = torch.clamp(shrunken_paste_mask, 0.0, 1.0)
+        elif shrunken_paste_mask is not None:
+            shrunken_paste_mask = np.clip(shrunken_paste_mask, 0.0, 1.0)
+
+        shrunken_cropped_mask_base = _impact_inset_mask_region(
+            cropped_mask_base, offset_x, offset_y, scaled_w, scaled_h
+        )
+        return cropped_image, enhanced_image, shrunken_paste_mask, shrunken_cropped_mask_base
 
     resized_image = utils.tensor_resize(enhanced_image, scaled_w, scaled_h)
     resized_paste_mask = torch.clamp(utils.tensor_resize(paste_mask, scaled_w, scaled_h), 0.0, 1.0)

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -935,6 +935,7 @@ class FaceDetailer:
                 segm_mask = core.segs_to_combined_mask(segm_segs)
                 segs = core.segs_bitwise_and_mask(segs, segm_mask)
 
+        mask_segs = segs
         if len(segs[1]) > 0:
             enhanced_img, _, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs = \
                 DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for_bbox, max_size, seed, steps, cfg,
@@ -945,7 +946,8 @@ class FaceDetailer:
                                           refiner_negative=refiner_negative,
                                           cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                           scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
-                                      post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
+                                          post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
+            mask_segs = new_segs
         else:
             enhanced_img = image
             cropped_enhanced = []
@@ -953,7 +955,7 @@ class FaceDetailer:
             cnet_pil_list = []
 
         # Mask Generator
-        mask = core.segs_to_combined_mask(segs)
+        mask = core.segs_to_combined_mask(mask_segs)
 
         if len(cropped_enhanced) == 0:
             cropped_enhanced = [utils.empty_pil_tensor()]

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import gc
 
 import comfy.samplers
 import comfy.sd
@@ -45,6 +46,42 @@ except Exception:
 warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is deprecated')
 
 model_path = folder_paths.models_dir
+
+
+def _impact_detailer_cleanup(label=None, clear_cuda_cache=True):
+    """Best-effort cleanup between FaceDetailer regions/frames.
+
+    This deliberately avoids unloading models. It only releases Python garbage,
+    synchronizes pending CUDA work, and clears allocator cache when available.
+    That makes failures surface at the detailer boundary instead of later nodes
+    and reduces allocator churn for large batched/detailer workflows.
+    """
+    gc.collect()
+
+    if not torch.cuda.is_available():
+        return
+
+    try:
+        torch.cuda.synchronize()
+    except Exception as e:
+        logging.warning(f"[Impact Pack] CUDA synchronize during FaceDetailer cleanup failed{f' ({label})' if label else ''}: {e}")
+
+    if not clear_cuda_cache:
+        return
+
+    try:
+        if hasattr(comfy.model_management, 'soft_empty_cache'):
+            comfy.model_management.soft_empty_cache()
+        else:
+            torch.cuda.empty_cache()
+    except Exception as e:
+        logging.warning(f"[Impact Pack] CUDA cache cleanup during FaceDetailer cleanup failed{f' ({label})' if label else ''}: {e}")
+
+
+def _impact_cpu_detached(tensor):
+    if torch.is_tensor(tensor):
+        return tensor.detach().cpu()
+    return tensor
 
 
 # folder_paths.supported_pt_extensions
@@ -494,7 +531,13 @@ class DetailerForEach:
             new_seg = SEG(new_seg_image, cropped_mask_for_output, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
             new_segs.append(new_seg)
 
-        image_tensor = utils.tensor_convert_rgb(image)
+            # Release transient CUDA allocator state before the next detected region.
+            # FaceDetailer can process multiple large crop regions for one image;
+            # without an explicit boundary, the next detector/detail pass can inherit
+            # stale pending CUDA work and allocator fragmentation.
+            _impact_detailer_cleanup(f"segment {i}")
+
+        image_tensor = utils.tensor_convert_rgb(image).detach().cpu()
 
         cropped_list.sort(key=lambda x: x.shape, reverse=True)
         enhanced_list.sort(key=lambda x: x.shape, reverse=True)
@@ -986,8 +1029,8 @@ class FaceDetailer:
              scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, post_detail_shrink=False,
              post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True, tile_size=0, tile_overlap=0):
 
-        result_img = None
-        result_mask = None
+        result_imgs = []
+        result_masks = []
         result_cropped_enhanced = []
         result_cropped_enhanced_alpha = []
         result_cnet_images = []
@@ -996,22 +1039,32 @@ class FaceDetailer:
             logging.warning("[Impact Pack] WARN: FaceDetailer is not a node designed for video detailing. If you intend to perform video detailing, please use Detailer For AnimateDiff.")
 
         for i, single_image in enumerate(image):
-            enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
-                single_image.unsqueeze(0), model, clip, vae, guide_size, guide_size_for, max_size, seed + i, steps, cfg, sampler_name, scheduler,
-                positive, negative, denoise, feather, noise_mask, force_inpaint,
-                bbox_threshold, bbox_dilation, bbox_crop_factor,
-                sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
-                sam_mask_hint_use_negative, drop_size, bbox_detector, segm_detector_opt, sam_model_opt, wildcard, detailer_hook,
-                cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
-                tiled_encode=tiled_encode, tiled_decode=tiled_decode,
-                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
-                force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
+            logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} start")
+            enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
+            try:
+                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
+                    single_image.unsqueeze(0), model, clip, vae, guide_size, guide_size_for, max_size, seed + i, steps, cfg, sampler_name, scheduler,
+                    positive, negative, denoise, feather, noise_mask, force_inpaint,
+                    bbox_threshold, bbox_dilation, bbox_crop_factor,
+                    sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
+                    sam_mask_hint_use_negative, drop_size, bbox_detector, segm_detector_opt, sam_model_opt, wildcard, detailer_hook,
+                    cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
+                    tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                    post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
+                    force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
 
-            result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
-            result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
-            result_cropped_enhanced.extend(cropped_enhanced)
-            result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
-            result_cnet_images.extend(cnet_pil_list)
+                result_imgs.append(_impact_cpu_detached(enhanced_img))
+                result_masks.append(_impact_cpu_detached(mask))
+                result_cropped_enhanced.extend(cropped_enhanced)
+                result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
+                result_cnet_images.extend(cnet_pil_list)
+            finally:
+                del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
+                _impact_detailer_cleanup(f"FaceDetailer frame {i + 1}")
+                logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} complete")
+
+        result_img = torch.cat(result_imgs, dim=0) if len(result_imgs) > 0 else image
+        result_mask = torch.cat(result_masks, dim=0) if len(result_masks) > 0 else torch.zeros((len(image), image.shape[1], image.shape[2]), dtype=torch.float32)
 
         pipe = (model, clip, vae, positive, negative, wildcard, bbox_detector, segm_detector_opt, sam_model_opt, detailer_hook, None, None, None, None)
         return result_img, result_cropped_enhanced, result_cropped_enhanced_alpha, result_mask, pipe, result_cnet_images
@@ -1824,8 +1877,8 @@ class FaceDetailerPipe:
              tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995,
              force_adaptive_tiled_encode=True, tile_size=0, tile_overlap=0):
 
-        result_img = None
-        result_mask = None
+        result_imgs = []
+        result_masks = []
         result_cropped_enhanced = []
         result_cropped_enhanced_alpha = []
         result_cnet_images = []
@@ -1837,24 +1890,34 @@ class FaceDetailerPipe:
             refiner_model, refiner_clip, refiner_positive, refiner_negative = detailer_pipe
 
         for i, single_image in enumerate(image):
-            enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
-                single_image.unsqueeze(0), model, clip, vae, guide_size, guide_size_for, max_size, seed + i, steps, cfg, sampler_name, scheduler,
-                positive, negative, denoise, feather, noise_mask, force_inpaint,
-                bbox_threshold, bbox_dilation, bbox_crop_factor,
-                sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
-                sam_mask_hint_use_negative, drop_size, bbox_detector, segm_detector, sam_model_opt, wildcard, detailer_hook,
-                refiner_ratio=refiner_ratio, refiner_model=refiner_model,
-                refiner_clip=refiner_clip, refiner_positive=refiner_positive, refiner_negative=refiner_negative,
-                cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
-                tiled_encode=tiled_encode, tiled_decode=tiled_decode,
-                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
-                force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
+            logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} start")
+            enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
+            try:
+                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
+                    single_image.unsqueeze(0), model, clip, vae, guide_size, guide_size_for, max_size, seed + i, steps, cfg, sampler_name, scheduler,
+                    positive, negative, denoise, feather, noise_mask, force_inpaint,
+                    bbox_threshold, bbox_dilation, bbox_crop_factor,
+                    sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
+                    sam_mask_hint_use_negative, drop_size, bbox_detector, segm_detector, sam_model_opt, wildcard, detailer_hook,
+                    refiner_ratio=refiner_ratio, refiner_model=refiner_model,
+                    refiner_clip=refiner_clip, refiner_positive=refiner_positive, refiner_negative=refiner_negative,
+                    cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
+                    tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                    post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
+                    force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
 
-            result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
-            result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
-            result_cropped_enhanced.extend(cropped_enhanced)
-            result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
-            result_cnet_images.extend(cnet_pil_list)
+                result_imgs.append(_impact_cpu_detached(enhanced_img))
+                result_masks.append(_impact_cpu_detached(mask))
+                result_cropped_enhanced.extend(cropped_enhanced)
+                result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
+                result_cnet_images.extend(cnet_pil_list)
+            finally:
+                del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
+                _impact_detailer_cleanup(f"FaceDetailerPipe frame {i + 1}")
+                logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} complete")
+
+        result_img = torch.cat(result_imgs, dim=0) if len(result_imgs) > 0 else image
+        result_mask = torch.cat(result_masks, dim=0) if len(result_masks) > 0 else torch.zeros((len(image), image.shape[1], image.shape[2]), dtype=torch.float32)
 
         if len(result_cropped_enhanced) == 0:
             result_cropped_enhanced = [utils.empty_pil_tensor()]

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -100,6 +100,15 @@ def _apply_post_detail_shrink(cropped_image, enhanced_image, paste_mask, cropped
 
     scale = max(0.01, min(1.0, scale))
 
+    # The default shrink value is 0.995. On large/detailer crops this causes an
+    # almost invisible resample of the finished patch, but it can lower apparent
+    # detail and has been observed to wedge right after "post_detail_shrink start".
+    # Treat near-identity shrink as a no-op. Users that need an actual shrink can
+    # still set a visibly smaller scale, e.g. <= 0.98.
+    if scale >= 0.99:
+        logging.info(f"Detailer: post-detail shrink skipped near-identity scale={scale:.4f}")
+        return cropped_image, enhanced_image, paste_mask, cropped_mask_base
+
     crop_w, crop_h = utils.tensor_get_size(enhanced_image)
     scaled_w = max(1, int(round(crop_w * scale)))
     scaled_h = max(1, int(round(crop_h * scale)))

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -48,13 +48,13 @@ warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is
 model_path = folder_paths.models_dir
 
 
-def _impact_detailer_cleanup(label=None, clear_cuda_cache=True, collect_python=True, synchronize=True):
+def _impact_detailer_cleanup(label=None, clear_cuda_cache=False, collect_python=False, synchronize=False):
     """Best-effort cleanup between FaceDetailer regions/frames.
 
-    This deliberately avoids unloading models. It only releases Python garbage,
-    synchronizes pending CUDA work, and clears allocator cache when requested.
-    Frame-level callers can use a lighter synchronization-only boundary because
-    DetailerForEach already performs deep cleanup after each processed segment.
+    This deliberately avoids unloading models. By default it is only an
+    instrumentation boundary; explicit CUDA sync/cache clearing from the
+    FaceDetailer hot path can itself become a WSL/CUDA wedge point across
+    queued generations. Callers may opt into heavier cleanup for diagnostics.
     """
     if collect_python:
         gc.collect()
@@ -609,11 +609,8 @@ class DetailerForEach:
             new_seg = SEG(new_seg_image, cropped_mask_for_output, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
             new_segs.append(new_seg)
 
-            # Release transient CUDA allocator state before the next detected region.
-            # FaceDetailer can process multiple large crop regions for one image;
-            # without an explicit boundary, the next detector/detail pass can inherit
-            # stale pending CUDA work and allocator fragmentation.
-            _impact_detailer_cleanup(f"segment {i}")
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} cleanup boundary")
+            _impact_detailer_cleanup(f"segment {i + 1}")
 
         image_tensor = utils.tensor_convert_rgb(image).detach().cpu()
 
@@ -1148,11 +1145,7 @@ class FaceDetailer:
             finally:
                 del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
                 logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} cleanup start")
-                _impact_detailer_cleanup(
-                    f"FaceDetailer frame {i + 1}",
-                    clear_cuda_cache=False,
-                    collect_python=False,
-                )
+                _impact_detailer_cleanup(f"FaceDetailer frame {i + 1}")
                 logging.info(
                     f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} "
                     f"{'complete' if frame_ok else 'failed'}"
@@ -2011,11 +2004,7 @@ class FaceDetailerPipe:
             finally:
                 del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
                 logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} cleanup start")
-                _impact_detailer_cleanup(
-                    f"FaceDetailerPipe frame {i + 1}",
-                    clear_cuda_cache=False,
-                    collect_python=False,
-                )
+                _impact_detailer_cleanup(f"FaceDetailerPipe frame {i + 1}")
                 logging.info(
                     f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} "
                     f"{'complete' if frame_ok else 'failed'}"

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -86,6 +86,42 @@ def _impact_cpu_detached(tensor):
     return tensor
 
 
+def _impact_copy_frame_image(dst, frame_index, image_tensor, *, label):
+    if not torch.is_tensor(image_tensor):
+        raise TypeError(f"[Impact Pack] {label} expected tensor image, got {type(image_tensor).__name__}")
+
+    image_tensor = image_tensor.detach().cpu()
+    if image_tensor.ndim == 3:
+        image_tensor = image_tensor.unsqueeze(0)
+
+    expected = dst[frame_index:frame_index + 1].shape
+    if tuple(image_tensor.shape) != tuple(expected):
+        raise ValueError(f"[Impact Pack] {label} returned image shape {tuple(image_tensor.shape)}, expected {tuple(expected)}")
+
+    dst[frame_index:frame_index + 1].copy_(image_tensor.to(dtype=dst.dtype, copy=False))
+
+
+def _impact_copy_frame_mask(dst, frame_index, mask_tensor, *, label):
+    if mask_tensor is None:
+        dst[frame_index].zero_()
+        return
+    if not torch.is_tensor(mask_tensor):
+        raise TypeError(f"[Impact Pack] {label} expected tensor mask, got {type(mask_tensor).__name__}")
+
+    mask_tensor = mask_tensor.detach().cpu()
+    if mask_tensor.ndim == 3:
+        if mask_tensor.shape[0] == 1:
+            mask_tensor = mask_tensor[0]
+        elif mask_tensor.shape[-1] == 1:
+            mask_tensor = mask_tensor[..., 0]
+
+    expected = dst[frame_index].shape
+    if tuple(mask_tensor.shape) != tuple(expected):
+        raise ValueError(f"[Impact Pack] {label} returned mask shape {tuple(mask_tensor.shape)}, expected {tuple(expected)}")
+
+    dst[frame_index].copy_(mask_tensor.to(dtype=dst.dtype, copy=False))
+
+
 def _impact_repair_detailer_tensor(tensor, *, fallback=None, label="tensor", clamp_image=False):
     """Return a finite CPU tensor for detailer paste/alpha boundaries.
 
@@ -1177,13 +1213,16 @@ class FaceDetailer:
 
         # bbox + sam combination
         if sam_model_opt is not None:
-            logging.info("[Impact Pack] FaceDetailer SAM refinement start segs=%d", len(segs[1]))
-            sam_mask = core.make_sam_mask(sam_model_opt, segs, image, sam_detection_hint, sam_dilation,
-                                          sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
-                                          sam_mask_hint_use_negative, )
-            logging.info("[Impact Pack] FaceDetailer SAM refinement mask complete shape=%s", tuple(sam_mask.shape))
-            segs = core.segs_bitwise_and_mask(segs, sam_mask)
-            logging.info("[Impact Pack] FaceDetailer SAM refinement complete segs=%d", len(segs[1]))
+            if len(segs[1]) > 0:
+                logging.info("[Impact Pack] FaceDetailer SAM refinement start segs=%d", len(segs[1]))
+                sam_mask = core.make_sam_mask(sam_model_opt, segs, image, sam_detection_hint, sam_dilation,
+                                              sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
+                                              sam_mask_hint_use_negative, )
+                logging.info("[Impact Pack] FaceDetailer SAM refinement mask complete shape=%s", tuple(sam_mask.shape))
+                segs = core.segs_bitwise_and_mask(segs, sam_mask)
+                logging.info("[Impact Pack] FaceDetailer SAM refinement complete segs=%d", len(segs[1]))
+            else:
+                logging.info("[Impact Pack] FaceDetailer SAM refinement skipped: no bbox segs")
 
         elif segm_detector is not None:
             logging.info("[Impact Pack] FaceDetailer segm refinement start segs=%d", len(segs[1]))
@@ -1199,6 +1238,7 @@ class FaceDetailer:
             logging.info("[Impact Pack] FaceDetailer segm refinement complete segs=%d", len(segs[1]))
 
         mask_segs = segs
+        detail_applied = False
         if len(segs[1]) > 0:
             logging.info("[Impact Pack] FaceDetailer detail pass start segs=%d", len(segs[1]))
             enhanced_img, _, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs = \
@@ -1214,6 +1254,7 @@ class FaceDetailer:
                                           auto_vae_tiled_encode=force_adaptive_tiled_encode,
                                           vae_tile_size=tile_size, vae_tile_overlap=tile_overlap)
             mask_segs = new_segs
+            detail_applied = True
             logging.info("[Impact Pack] FaceDetailer detail pass complete new_segs=%d", len(new_segs[1]))
         else:
             logging.info("[Impact Pack] FaceDetailer detail pass skipped: no segs")
@@ -1234,7 +1275,7 @@ class FaceDetailer:
         if len(cnet_pil_list) == 0:
             cnet_pil_list = [utils.empty_pil_tensor()]
 
-        return enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
+        return enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list, detail_applied
 
     def doit(self, image, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name, scheduler,
              positive, negative, denoise, feather, noise_mask, force_inpaint,
@@ -1245,8 +1286,9 @@ class FaceDetailer:
              scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, post_detail_shrink=False,
              post_detail_shrink_scale=0.995, force_adaptive_tiled_encode=True, tile_size=0, tile_overlap=0):
 
-        result_imgs = []
-        result_masks = []
+        result_img = None
+        result_mask = torch.empty((len(image), image.shape[1], image.shape[2]), dtype=torch.float32, device="cpu")
+        any_detail_applied = False
         result_cropped_enhanced = []
         result_cropped_enhanced_alpha = []
         result_cnet_images = []
@@ -1258,8 +1300,9 @@ class FaceDetailer:
             frame_ok = False
             logging.info("[Impact Pack] FaceDetailer frame %d/%d start", i + 1, len(image))
             enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
+            detail_applied = False
             try:
-                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
+                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list, detail_applied = FaceDetailer.enhance_face(
                     single_image.unsqueeze(0), model, clip, vae, guide_size, guide_size_for, max_size, seed + i, steps, cfg, sampler_name, scheduler,
                     positive, negative, denoise, feather, noise_mask, force_inpaint,
                     bbox_threshold, bbox_dilation, bbox_crop_factor,
@@ -1270,8 +1313,14 @@ class FaceDetailer:
                     post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
                     force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
 
-                result_imgs.append(_impact_cpu_detached(enhanced_img))
-                result_masks.append(_impact_cpu_detached(mask))
+                if detail_applied and result_img is None:
+                    logging.info("[Impact Pack] FaceDetailer output clone start shape=%s", tuple(image.shape))
+                    result_img = image.detach().cpu().clone()
+                    logging.info("[Impact Pack] FaceDetailer output clone complete shape=%s", tuple(result_img.shape))
+                if result_img is not None:
+                    _impact_copy_frame_image(result_img, i, enhanced_img, label=f"FaceDetailer frame {i + 1}")
+                _impact_copy_frame_mask(result_mask, i, mask, label=f"FaceDetailer frame {i + 1}")
+                any_detail_applied = any_detail_applied or detail_applied
                 result_cropped_enhanced.extend(cropped_enhanced)
                 result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
                 result_cnet_images.extend(cnet_pil_list)
@@ -1285,8 +1334,10 @@ class FaceDetailer:
                     f"{'complete' if frame_ok else 'failed'}"
                 )
 
-        result_img = torch.cat(result_imgs, dim=0) if len(result_imgs) > 0 else image
-        result_mask = torch.cat(result_masks, dim=0) if len(result_masks) > 0 else torch.zeros((len(image), image.shape[1], image.shape[2]), dtype=torch.float32)
+        logging.info("[Impact Pack] FaceDetailer aggregate start any_detail_applied=%s", any_detail_applied)
+        if result_img is None:
+            result_img = image.detach().cpu()
+        logging.info("[Impact Pack] FaceDetailer aggregate complete image=%s mask=%s", tuple(result_img.shape), tuple(result_mask.shape))
 
         pipe = (model, clip, vae, positive, negative, wildcard, bbox_detector, segm_detector_opt, sam_model_opt, detailer_hook, None, None, None, None)
         return result_img, result_cropped_enhanced, result_cropped_enhanced_alpha, result_mask, pipe, result_cnet_images
@@ -2099,8 +2150,9 @@ class FaceDetailerPipe:
              tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995,
              force_adaptive_tiled_encode=True, tile_size=0, tile_overlap=0):
 
-        result_imgs = []
-        result_masks = []
+        result_img = None
+        result_mask = torch.empty((len(image), image.shape[1], image.shape[2]), dtype=torch.float32, device="cpu")
+        any_detail_applied = False
         result_cropped_enhanced = []
         result_cropped_enhanced_alpha = []
         result_cnet_images = []
@@ -2115,8 +2167,9 @@ class FaceDetailerPipe:
             frame_ok = False
             logging.info("[Impact Pack] FaceDetailerPipe frame %d/%d start", i + 1, len(image))
             enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
+            detail_applied = False
             try:
-                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
+                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list, detail_applied = FaceDetailer.enhance_face(
                     single_image.unsqueeze(0), model, clip, vae, guide_size, guide_size_for, max_size, seed + i, steps, cfg, sampler_name, scheduler,
                     positive, negative, denoise, feather, noise_mask, force_inpaint,
                     bbox_threshold, bbox_dilation, bbox_crop_factor,
@@ -2129,8 +2182,14 @@ class FaceDetailerPipe:
                     post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale,
                     force_adaptive_tiled_encode=force_adaptive_tiled_encode, tile_size=tile_size, tile_overlap=tile_overlap)
 
-                result_imgs.append(_impact_cpu_detached(enhanced_img))
-                result_masks.append(_impact_cpu_detached(mask))
+                if detail_applied and result_img is None:
+                    logging.info("[Impact Pack] FaceDetailerPipe output clone start shape=%s", tuple(image.shape))
+                    result_img = image.detach().cpu().clone()
+                    logging.info("[Impact Pack] FaceDetailerPipe output clone complete shape=%s", tuple(result_img.shape))
+                if result_img is not None:
+                    _impact_copy_frame_image(result_img, i, enhanced_img, label=f"FaceDetailerPipe frame {i + 1}")
+                _impact_copy_frame_mask(result_mask, i, mask, label=f"FaceDetailerPipe frame {i + 1}")
+                any_detail_applied = any_detail_applied or detail_applied
                 result_cropped_enhanced.extend(cropped_enhanced)
                 result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
                 result_cnet_images.extend(cnet_pil_list)
@@ -2144,8 +2203,10 @@ class FaceDetailerPipe:
                     f"{'complete' if frame_ok else 'failed'}"
                 )
 
-        result_img = torch.cat(result_imgs, dim=0) if len(result_imgs) > 0 else image
-        result_mask = torch.cat(result_masks, dim=0) if len(result_masks) > 0 else torch.zeros((len(image), image.shape[1], image.shape[2]), dtype=torch.float32)
+        logging.info("[Impact Pack] FaceDetailerPipe aggregate start any_detail_applied=%s", any_detail_applied)
+        if result_img is None:
+            result_img = image.detach().cpu()
+        logging.info("[Impact Pack] FaceDetailerPipe aggregate complete image=%s mask=%s", tuple(result_img.shape), tuple(result_mask.shape))
 
         if len(result_cropped_enhanced) == 0:
             result_cropped_enhanced = [utils.empty_pil_tensor()]

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -341,7 +341,7 @@ class DetailerForEach:
                   positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard_opt=None, detailer_hook=None,
                   refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None,
                   cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
-                  post_detail_shrink=False, post_detail_shrink_scale=0.995, auto_vae_tiled_encode=False):
+                  post_detail_shrink=False, post_detail_shrink_scale=0.995, auto_vae_tiled_encode=False, vae_tile_size=None, vae_tile_overlap=None):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -446,7 +446,8 @@ class DetailerForEach:
                                                                 refiner_negative=refiner_negative, control_net_wrapper=seg.control_net_wrapper,
                                                                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
                                                                 scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
-                                                                vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode)
+                                                                vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode,
+                                                                vae_tile_size=vae_tile_size, vae_tile_overlap=vae_tile_overlap)
             else:
                 enhanced_image = cropped_image
                 cnet_pils = None

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -453,7 +453,7 @@ class DetailerForEach:
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
-        logging.info(f"[Impact Pack] DetailerForEach enter image={tuple(image.shape)} segs={len(segs[1])}")
+        logging.info("[Impact Pack] DetailerForEach enter image=%s segs=%d", tuple(image.shape), len(segs[1]))
         image = image.clone()
         enhanced_alpha_list = []
         enhanced_list = []
@@ -462,7 +462,7 @@ class DetailerForEach:
 
         logging.info("[Impact Pack] DetailerForEach segs_scale_match start")
         segs = core.segs_scale_match(segs, image.shape)
-        logging.info(f"[Impact Pack] DetailerForEach segs_scale_match complete segs={len(segs[1])}")
+        logging.info("[Impact Pack] DetailerForEach segs_scale_match complete segs=%d", len(segs[1]))
         new_segs = []
 
         wildcard_concat_mode = None
@@ -492,15 +492,14 @@ class DetailerForEach:
             model = utils.apply_differential_diffusion(model)
             logging.info("[Impact Pack] DetailerForEach apply_differential_diffusion complete")
 
-        image_np = image.detach().cpu().numpy()
         for i, seg in enumerate(ordered_segs):
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre crop start region={seg.crop_region} bbox={seg.bbox} label={seg.label}")
-            cropped_image = utils.crop_ndarray4(image_np, seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
+            logging.info("[Impact Pack] Detailer segment %d/%d pre crop start region=%s bbox=%s label=%s", i + 1, len(ordered_segs), seg.crop_region, seg.bbox, seg.label)
+            cropped_image = utils.crop_ndarray4(image.detach().cpu().numpy(), seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
             cropped_image = utils.to_tensor(cropped_image)
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask start crop={tuple(cropped_image.shape)}")
+            logging.info("[Impact Pack] Detailer segment %d/%d pre mask start crop=%s", i + 1, len(ordered_segs), tuple(cropped_image.shape))
             mask = utils.to_tensor(seg.cropped_mask)
             mask = utils.tensor_gaussian_blur_mask(mask, feather)
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask complete mask={tuple(mask.shape)}")
+            logging.info("[Impact Pack] Detailer segment %d/%d pre mask complete mask=%s", i + 1, len(ordered_segs), tuple(mask.shape))
 
             is_mask_all_zeros = (seg.cropped_mask == 0).all().item()
             if is_mask_all_zeros:
@@ -521,7 +520,7 @@ class DetailerForEach:
 
             seg_seed = seed + i if seg_seed is None else seg_seed
 
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop start")
+            logging.info("[Impact Pack] Detailer segment %d/%d conditioning crop start", i + 1, len(ordered_segs))
             if not isinstance(positive, str):
                 cropped_positive = [
                     [condition, {
@@ -544,7 +543,7 @@ class DetailerForEach:
             else:
                 # Negative Conditioning is placeholder such as FLUX.1
                 cropped_negative = negative
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop complete")
+            logging.info("[Impact Pack] Detailer segment %d/%d conditioning crop complete", i + 1, len(ordered_segs))
 
             if wildcard_item and wildcard_item.strip() == '[SKIP]':
                 continue
@@ -554,7 +553,7 @@ class DetailerForEach:
 
             orig_cropped_image = cropped_image.clone()
             if not (isinstance(model, str) and model == "DUMMY"):
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} enhance_detail start crop={tuple(cropped_image.shape)}")
+                logging.info("[Impact Pack] Detailer segment %d/%d enhance_detail start crop=%s", i + 1, len(ordered_segs), tuple(cropped_image.shape))
                 enhanced_image, cnet_pils = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
                                                                 seg.bbox, seg_seed, steps, cfg, sampler_name, scheduler,
                                                                 cropped_positive, cropped_negative, denoise, cropped_mask, force_inpaint,
@@ -567,12 +566,12 @@ class DetailerForEach:
                                                                 scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
                                                                 vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode,
                                                                 vae_tile_size=vae_tile_size, vae_tile_overlap=vae_tile_overlap)
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} enhance_detail returned shape={None if enhanced_image is None else tuple(enhanced_image.shape)}")
+                logging.info("[Impact Pack] Detailer segment %d/%d enhance_detail returned shape=%s", i + 1, len(ordered_segs), None if enhanced_image is None else tuple(enhanced_image.shape))
             else:
                 enhanced_image = cropped_image
                 cnet_pils = None
 
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} post_detail_shrink start")
+            logging.info("[Impact Pack] Detailer segment %d/%d post_detail_shrink start", i + 1, len(ordered_segs))
             orig_cropped_image, enhanced_image, mask, cropped_mask_for_output = _apply_post_detail_shrink(
                     orig_cropped_image,
                     enhanced_image,
@@ -593,9 +592,9 @@ class DetailerForEach:
                 image = image.detach().cpu()
                 enhanced_image = enhanced_image.detach().cpu()
                 mask = mask.detach().cpu()
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste start region={seg.crop_region} enhanced={tuple(enhanced_image.shape)} mask={tuple(mask.shape)}")
+                logging.info("[Impact Pack] Detailer segment %d/%d paste start region=%s enhanced=%s mask=%s", i + 1, len(ordered_segs), seg.crop_region, tuple(enhanced_image.shape), tuple(mask.shape))
                 utils.tensor_paste(image, enhanced_image, (seg.crop_region[0], seg.crop_region[1]), mask)  # this code affecting to `cropped_image`.
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste complete")
+                logging.info("[Impact Pack] Detailer segment %d/%d paste complete", i + 1, len(ordered_segs))
                 enhanced_list.append(enhanced_image)
 
                 if detailer_hook is not None:
@@ -603,7 +602,7 @@ class DetailerForEach:
 
             if enhanced_image is not None:
                 # Convert enhanced_pil_alpha to RGBA mode
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output start")
+                logging.info("[Impact Pack] Detailer segment %d/%d alpha output start", i + 1, len(ordered_segs))
                 enhanced_image_alpha = utils.tensor_convert_rgba(enhanced_image)
                 new_seg_image = enhanced_image.numpy()  # alpha should not be applied to seg_image
 
@@ -611,7 +610,7 @@ class DetailerForEach:
                 mask = utils.tensor_resize_for_detailer_output(mask, *utils.tensor_get_size(enhanced_image))
                 utils.tensor_putalpha(enhanced_image_alpha, mask)
                 enhanced_alpha_list.append(enhanced_image_alpha)
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output complete")
+                logging.info("[Impact Pack] Detailer segment %d/%d alpha output complete", i + 1, len(ordered_segs))
             else:
                 new_seg_image = None
 
@@ -620,7 +619,7 @@ class DetailerForEach:
             new_seg = SEG(new_seg_image, cropped_mask_for_output, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
             new_segs.append(new_seg)
 
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} cleanup boundary")
+            logging.info("[Impact Pack] Detailer segment %d/%d cleanup boundary", i + 1, len(ordered_segs))
             _impact_detailer_cleanup(f"segment {i + 1}")
 
         image_tensor = utils.tensor_convert_rgb(image).detach().cpu()
@@ -709,7 +708,7 @@ class DetailerForEachAutoRetry:
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
-        logging.info(f"[Impact Pack] DetailerForEach enter image={tuple(image.shape)} segs={len(segs[1])}")
+        logging.info("[Impact Pack] DetailerForEach enter image=%s segs=%d", tuple(image.shape), len(segs[1]))
         image = image.clone()
         enhanced_alpha_list = []
         enhanced_list = []
@@ -718,7 +717,7 @@ class DetailerForEachAutoRetry:
 
         logging.info("[Impact Pack] DetailerForEach segs_scale_match start")
         segs = core.segs_scale_match(segs, image.shape)
-        logging.info(f"[Impact Pack] DetailerForEach segs_scale_match complete segs={len(segs[1])}")
+        logging.info("[Impact Pack] DetailerForEach segs_scale_match complete segs=%d", len(segs[1]))
         new_segs = []
 
         wildcard_concat_mode = None
@@ -748,15 +747,14 @@ class DetailerForEachAutoRetry:
             model = utils.apply_differential_diffusion(model)
             logging.info("[Impact Pack] DetailerForEach apply_differential_diffusion complete")
 
-        image_np = image.detach().cpu().numpy()
         for i, seg in enumerate(ordered_segs):
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre crop start region={seg.crop_region} bbox={seg.bbox} label={seg.label}")
-            cropped_image = utils.crop_ndarray4(image_np, seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
+            logging.info("[Impact Pack] Detailer segment %d/%d pre crop start region=%s bbox=%s label=%s", i + 1, len(ordered_segs), seg.crop_region, seg.bbox, seg.label)
+            cropped_image = utils.crop_ndarray4(image.detach().cpu().numpy(), seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
             cropped_image = utils.to_tensor(cropped_image)
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask start crop={tuple(cropped_image.shape)}")
+            logging.info("[Impact Pack] Detailer segment %d/%d pre mask start crop=%s", i + 1, len(ordered_segs), tuple(cropped_image.shape))
             mask = utils.to_tensor(seg.cropped_mask)
             mask = utils.tensor_gaussian_blur_mask(mask, feather)
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask complete mask={tuple(mask.shape)}")
+            logging.info("[Impact Pack] Detailer segment %d/%d pre mask complete mask=%s", i + 1, len(ordered_segs), tuple(mask.shape))
 
             is_mask_all_zeros = (seg.cropped_mask == 0).all().item()
             if is_mask_all_zeros:
@@ -777,7 +775,7 @@ class DetailerForEachAutoRetry:
 
             seg_seed = seed + i if seg_seed is None else seg_seed
 
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop start")
+            logging.info("[Impact Pack] Detailer segment %d/%d conditioning crop start", i + 1, len(ordered_segs))
             if not isinstance(positive, str):
                 cropped_positive = [
                     [condition, {
@@ -800,7 +798,7 @@ class DetailerForEachAutoRetry:
             else:
                 # Negative Conditioning is placeholder such as FLUX.1
                 cropped_negative = negative
-            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop complete")
+            logging.info("[Impact Pack] Detailer segment %d/%d conditioning crop complete", i + 1, len(ordered_segs))
 
             if wildcard_item and wildcard_item.strip() == '[SKIP]':
                 continue
@@ -816,7 +814,7 @@ class DetailerForEachAutoRetry:
 
             if not (isinstance(model, str) and model == "DUMMY"):
                 for retry in range(max_retries):
-                    logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} retry {retry + 1}/{max_retries} enhance_detail start crop={tuple(cropped_image.shape)}")
+                    logging.info("[Impact Pack] Detailer segment %d/%d retry %d/%d enhance_detail start crop=%s", i + 1, len(ordered_segs), retry + 1, max_retries, tuple(cropped_image.shape))
                     enhanced_image, cnet_pils = core.enhance_detail(cropped_image, model, clip, vae, guide_size, guide_size_for_bbox, max_size,
                                                                     seg.bbox, seg_seed + retry, steps, cfg, sampler_name, scheduler,
                                                                     cropped_positive, cropped_negative, denoise, cropped_mask, force_inpaint,
@@ -829,7 +827,7 @@ class DetailerForEachAutoRetry:
                                                                     scheduler_func=scheduler_func_opt, vae_tiled_encode=tiled_encode,
                                                                     vae_tiled_decode=tiled_decode, auto_vae_tiled_encode=auto_vae_tiled_encode,
                                                                     vae_tile_size=vae_tile_size, vae_tile_overlap=vae_tile_overlap)
-                    logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} retry {retry + 1}/{max_retries} enhance_detail returned shape={None if enhanced_image is None else tuple(enhanced_image.shape)}")
+                    logging.info("[Impact Pack] Detailer segment %d/%d retry %d/%d enhance_detail returned shape=%s", i + 1, len(ordered_segs), retry + 1, max_retries, None if enhanced_image is None else tuple(enhanced_image.shape))
 
                     if detailer_hook is None or not detailer_hook.should_retry_patch(enhanced_image):
                         break
@@ -859,9 +857,9 @@ class DetailerForEachAutoRetry:
                 image = image.detach().cpu()
                 enhanced_image = enhanced_image.detach().cpu()
                 mask = mask.detach().cpu()
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste start region={seg.crop_region} enhanced={tuple(enhanced_image.shape)} mask={tuple(mask.shape)}")
+                logging.info("[Impact Pack] Detailer segment %d/%d paste start region=%s enhanced=%s mask=%s", i + 1, len(ordered_segs), seg.crop_region, tuple(enhanced_image.shape), tuple(mask.shape))
                 utils.tensor_paste(image, enhanced_image, (seg.crop_region[0], seg.crop_region[1]), mask)  # this code affecting to `cropped_image`.
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} paste complete")
+                logging.info("[Impact Pack] Detailer segment %d/%d paste complete", i + 1, len(ordered_segs))
                 enhanced_list.append(enhanced_image)
 
                 if detailer_hook is not None:
@@ -869,7 +867,7 @@ class DetailerForEachAutoRetry:
 
             if enhanced_image is not None:
                 # Convert enhanced_pil_alpha to RGBA mode
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output start")
+                logging.info("[Impact Pack] Detailer segment %d/%d alpha output start", i + 1, len(ordered_segs))
                 enhanced_image_alpha = utils.tensor_convert_rgba(enhanced_image)
                 new_seg_image = enhanced_image.numpy()  # alpha should not be applied to seg_image
 
@@ -877,7 +875,7 @@ class DetailerForEachAutoRetry:
                 mask = utils.tensor_resize_for_detailer_output(mask, *utils.tensor_get_size(enhanced_image))
                 utils.tensor_putalpha(enhanced_image_alpha, mask)
                 enhanced_alpha_list.append(enhanced_image_alpha)
-                logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} alpha output complete")
+                logging.info("[Impact Pack] Detailer segment %d/%d alpha output complete", i + 1, len(ordered_segs))
             else:
                 new_seg_image = None
 
@@ -1068,28 +1066,28 @@ class FaceDetailer:
                      tile_size=0, tile_overlap=0):
 
         # make default prompt as 'face' if empty prompt for CLIPSeg
-        logging.info(f"[Impact Pack] FaceDetailer bbox detect start image={tuple(image.shape)} threshold={bbox_threshold} dilation={bbox_dilation} crop_factor={bbox_crop_factor}")
+        logging.info("[Impact Pack] FaceDetailer bbox detect start image=%s threshold=%s dilation=%s crop_factor=%s", tuple(image.shape), bbox_threshold, bbox_dilation, bbox_crop_factor)
         bbox_detector.setAux('face')
         try:
             segs = bbox_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor, drop_size, detailer_hook=detailer_hook)
         finally:
             bbox_detector.setAux(None)
-        logging.info(f"[Impact Pack] FaceDetailer bbox detect complete segs={len(segs[1])}")
+        logging.info("[Impact Pack] FaceDetailer bbox detect complete segs=%d", len(segs[1]))
 
         # bbox + sam combination
         if sam_model_opt is not None:
-            logging.info(f"[Impact Pack] FaceDetailer SAM refinement start segs={len(segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer SAM refinement start segs=%d", len(segs[1]))
             sam_mask = core.make_sam_mask(sam_model_opt, segs, image, sam_detection_hint, sam_dilation,
                                           sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
                                           sam_mask_hint_use_negative, )
-            logging.info(f"[Impact Pack] FaceDetailer SAM refinement mask complete shape={tuple(sam_mask.shape)}")
+            logging.info("[Impact Pack] FaceDetailer SAM refinement mask complete shape=%s", tuple(sam_mask.shape))
             segs = core.segs_bitwise_and_mask(segs, sam_mask)
-            logging.info(f"[Impact Pack] FaceDetailer SAM refinement complete segs={len(segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer SAM refinement complete segs=%d", len(segs[1]))
 
         elif segm_detector is not None:
-            logging.info(f"[Impact Pack] FaceDetailer segm refinement start segs={len(segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer segm refinement start segs=%d", len(segs[1]))
             segm_segs = segm_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor, drop_size)
-            logging.info(f"[Impact Pack] FaceDetailer segm detector complete segs={len(segm_segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer segm detector complete segs=%d", len(segm_segs[1]))
 
             if (hasattr(segm_detector, 'override_bbox_by_segm') and segm_detector.override_bbox_by_segm and
                     not (detailer_hook is not None and not hasattr(detailer_hook, 'override_bbox_by_segm'))):
@@ -1097,11 +1095,11 @@ class FaceDetailer:
             else:
                 segm_mask = core.segs_to_combined_mask(segm_segs)
                 segs = core.segs_bitwise_and_mask(segs, segm_mask)
-            logging.info(f"[Impact Pack] FaceDetailer segm refinement complete segs={len(segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer segm refinement complete segs=%d", len(segs[1]))
 
         mask_segs = segs
         if len(segs[1]) > 0:
-            logging.info(f"[Impact Pack] FaceDetailer detail pass start segs={len(segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer detail pass start segs=%d", len(segs[1]))
             enhanced_img, _, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs = \
                 DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for_bbox, max_size, seed, steps, cfg,
                                           sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
@@ -1115,7 +1113,7 @@ class FaceDetailer:
                                           auto_vae_tiled_encode=force_adaptive_tiled_encode,
                                           vae_tile_size=tile_size, vae_tile_overlap=tile_overlap)
             mask_segs = new_segs
-            logging.info(f"[Impact Pack] FaceDetailer detail pass complete new_segs={len(new_segs[1])}")
+            logging.info("[Impact Pack] FaceDetailer detail pass complete new_segs=%d", len(new_segs[1]))
         else:
             logging.info("[Impact Pack] FaceDetailer detail pass skipped: no segs")
             enhanced_img = image
@@ -1157,7 +1155,7 @@ class FaceDetailer:
 
         for i, single_image in enumerate(image):
             frame_ok = False
-            logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} start")
+            logging.info("[Impact Pack] FaceDetailer frame %d/%d start", i + 1, len(image))
             enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
             try:
                 enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
@@ -1179,7 +1177,7 @@ class FaceDetailer:
                 frame_ok = True
             finally:
                 del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
-                logging.info(f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} cleanup start")
+                logging.info("[Impact Pack] FaceDetailer frame %d/%d cleanup start", i + 1, len(image))
                 _impact_detailer_cleanup(f"FaceDetailer frame {i + 1}")
                 logging.info(
                     f"[Impact Pack] FaceDetailer frame {i + 1}/{len(image)} "
@@ -2014,7 +2012,7 @@ class FaceDetailerPipe:
 
         for i, single_image in enumerate(image):
             frame_ok = False
-            logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} start")
+            logging.info("[Impact Pack] FaceDetailerPipe frame %d/%d start", i + 1, len(image))
             enhanced_img = cropped_enhanced = cropped_enhanced_alpha = mask = cnet_pil_list = None
             try:
                 enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = FaceDetailer.enhance_face(
@@ -2038,7 +2036,7 @@ class FaceDetailerPipe:
                 frame_ok = True
             finally:
                 del enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
-                logging.info(f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} cleanup start")
+                logging.info("[Impact Pack] FaceDetailerPipe frame %d/%d cleanup start", i + 1, len(image))
                 _impact_detailer_cleanup(f"FaceDetailerPipe frame {i + 1}")
                 logging.info(
                     f"[Impact Pack] FaceDetailerPipe frame {i + 1}/{len(image)} "

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -52,6 +52,80 @@ utils.add_folder_path_and_extensions("sams", [os.path.join(model_path, "sams")],
 utils.add_folder_path_and_extensions("onnx", [os.path.join(model_path, "onnx")], {'.onnx'})
 
 
+def _apply_post_detail_shrink(cropped_image, enhanced_image, paste_mask, cropped_mask_base,
+                              paste_crop_region, bbox, enabled=False, scale=0.995):
+    if enhanced_image is None or not enabled:
+        return cropped_image, enhanced_image, paste_mask, cropped_mask_base
+
+    scale = float(scale)
+    if scale >= 0.999999:
+        return cropped_image, enhanced_image, paste_mask, cropped_mask_base
+
+    scale = max(0.01, min(1.0, scale))
+
+    crop_w, crop_h = utils.tensor_get_size(enhanced_image)
+    scaled_w = max(1, int(round(crop_w * scale)))
+    scaled_h = max(1, int(round(crop_h * scale)))
+
+    if scaled_w == crop_w and scaled_h == crop_h:
+        return cropped_image, enhanced_image, paste_mask, cropped_mask_base
+
+    bbox_cx = (bbox[0] + bbox[2]) * 0.5 - paste_crop_region[0]
+    bbox_cy = (bbox[1] + bbox[3]) * 0.5 - paste_crop_region[1]
+    bbox_cx = min(max(float(bbox_cx), 0.0), max(crop_w - 1, 0))
+    bbox_cy = min(max(float(bbox_cy), 0.0), max(crop_h - 1, 0))
+
+    offset_x = int(round(bbox_cx - bbox_cx * scale))
+    offset_y = int(round(bbox_cy - bbox_cy * scale))
+    offset_x = min(max(offset_x, 0), max(crop_w - scaled_w, 0))
+    offset_y = min(max(offset_y, 0), max(crop_h - scaled_h, 0))
+
+    resized_image = utils.tensor_resize(enhanced_image, scaled_w, scaled_h)
+    resized_paste_mask = torch.clamp(utils.tensor_resize(paste_mask, scaled_w, scaled_h), 0.0, 1.0)
+
+    cropped_mask_base_is_numpy = isinstance(cropped_mask_base, np.ndarray)
+    cropped_mask_base_src = utils.to_tensor(cropped_mask_base) if cropped_mask_base_is_numpy else cropped_mask_base
+
+    resized_cropped_mask_base = torch.clamp(
+        utils.resize_mask(cropped_mask_base_src, (scaled_h, scaled_w)),
+        0.0,
+        1.0,
+    )
+
+    if getattr(cropped_mask_base, "ndim", None) == 2 and resized_cropped_mask_base.ndim == 3:
+        resized_cropped_mask_base = resized_cropped_mask_base.squeeze(0)
+
+    if cropped_mask_base_is_numpy:
+        resized_cropped_mask_base = resized_cropped_mask_base.cpu().numpy()
+
+    shrunken_image = cropped_image.clone()
+    utils.tensor_paste(shrunken_image, resized_image, (offset_x, offset_y), resized_paste_mask)
+
+    shrunken_paste_mask = utils.shift_within_canvas(
+        resized_paste_mask,
+        offset_x,
+        offset_y,
+        canvas_w=crop_w,
+        canvas_h=crop_h,
+        fill_value=0.0,
+    )
+    shrunken_cropped_mask_base = utils.shift_within_canvas(
+        resized_cropped_mask_base,
+        offset_x,
+        offset_y,
+        canvas_w=crop_w,
+        canvas_h=crop_h,
+        fill_value=0.0,
+    )
+
+    logging.info(
+        f"Detailer: post-detail shrink scale={scale:.4f} offset=({offset_x}, {offset_y}) "
+        f"size=({crop_w}, {crop_h})->({scaled_w}, {scaled_h})"
+    )
+
+    return cropped_image, shrunken_image, shrunken_paste_mask, shrunken_cropped_mask_base
+
+
 # Nodes
 class ONNXDetectorProvider:
     @classmethod
@@ -246,6 +320,8 @@ class DetailerForEach:
                     "scheduler_func_opt": ("SCHEDULER_FUNC",),
                     "tiled_encode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                     "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
+                    "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
+                    "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                    }
                 }
 
@@ -264,7 +340,8 @@ class DetailerForEach:
     def do_detail(image, segs, model, clip, vae, guide_size, guide_size_for_bbox, max_size, seed, steps, cfg, sampler_name, scheduler,
                   positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard_opt=None, detailer_hook=None,
                   refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None,
-                  cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False):
+                  cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
+                  post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -374,6 +451,17 @@ class DetailerForEach:
                 enhanced_image = cropped_image
                 cnet_pils = None
 
+            orig_cropped_image, enhanced_image, mask, cropped_mask_for_output = _apply_post_detail_shrink(
+                    orig_cropped_image,
+                    enhanced_image,
+                    mask,
+                    seg.cropped_mask,
+                    seg.crop_region,
+                    seg.bbox,
+                    enabled=post_detail_shrink,
+                    scale=post_detail_shrink_scale,
+                )
+
             if cnet_pils is not None:
                 cnet_pil_list.extend(cnet_pils)
 
@@ -402,7 +490,7 @@ class DetailerForEach:
 
             cropped_list.append(orig_cropped_image) # NOTE: Don't use `cropped_image`
 
-            new_seg = SEG(new_seg_image, seg.cropped_mask, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
+            new_seg = SEG(new_seg_image, cropped_mask_for_output, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
             new_segs.append(new_seg)
 
         image_tensor = utils.tensor_convert_rgb(image)
@@ -416,14 +504,15 @@ class DetailerForEach:
     def doit(self, image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name,
              scheduler, positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard, cycle=1,
              detailer_hook=None, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
-             tiled_encode=False, tiled_decode=False):
+             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         enhanced_img, *_ = \
             DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps,
                                       cfg, sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
                                       cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
-                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                                      post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
 
         return (enhanced_img, )
 
@@ -463,6 +552,8 @@ class DetailerForEachAutoRetry:
                     "scheduler_func_opt": ("SCHEDULER_FUNC",),
                     "tiled_encode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                     "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
+                    "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
+                    "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                    }
                 }
 
@@ -481,7 +572,8 @@ class DetailerForEachAutoRetry:
     def do_detail(image, segs, model, clip, vae, guide_size, guide_size_for_bbox, max_size, seed, steps, cfg, sampler_name, scheduler,
                   positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard_opt=None, detailer_hook=None,
                   refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None,
-                  cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, max_retries=1):
+                  cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
+                  post_detail_shrink=False, post_detail_shrink_scale=0.995, max_retries=1):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -602,6 +694,17 @@ class DetailerForEachAutoRetry:
                     else:
                         print("Detect bad patch, retrying...")
 
+            orig_cropped_image, enhanced_image, mask, cropped_mask_for_output = _apply_post_detail_shrink(
+                    orig_cropped_image,
+                    enhanced_image,
+                    mask,
+                    seg.cropped_mask,
+                    seg.crop_region,
+                    seg.bbox,
+                    enabled=post_detail_shrink,
+                    scale=post_detail_shrink_scale,
+                )
+
             if cnet_pils is not None:
                 cnet_pil_list.extend(cnet_pils)
 
@@ -630,7 +733,7 @@ class DetailerForEachAutoRetry:
 
             cropped_list.append(orig_cropped_image) # NOTE: Don't use `cropped_image`
 
-            new_seg = SEG(new_seg_image, seg.cropped_mask, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
+            new_seg = SEG(new_seg_image, cropped_mask_for_output, seg.confidence, seg.crop_region, seg.bbox, seg.label, seg.control_net_wrapper)
             new_segs.append(new_seg)
 
         image_tensor = utils.tensor_convert_rgb(image)
@@ -644,14 +747,15 @@ class DetailerForEachAutoRetry:
     def doit(self, image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name,
              scheduler, positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard, cycle=1,
              detailer_hook=None, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
-             tiled_encode=False, tiled_decode=False, max_retries=1):
+             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995, max_retries=1):
 
         enhanced_img, *_ = \
             DetailerForEachAutoRetry.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps,
                                       cfg, sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
                                       cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
-                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode, max_retries=max_retries)
+                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                                      post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale, max_retries=max_retries)
 
         return (enhanced_img, )
 
@@ -688,6 +792,8 @@ class DetailerForEachPipe:
                       "scheduler_func_opt": ("SCHEDULER_FUNC",),
                       "tiled_encode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                       "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
+                      "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
+                      "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                      }
                 }
 
@@ -704,7 +810,7 @@ class DetailerForEachPipe:
              denoise, feather, noise_mask, force_inpaint, basic_pipe, wildcard,
              refiner_ratio=None, detailer_hook=None, refiner_basic_pipe_opt=None,
              cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
-             tiled_encode=False, tiled_decode=False):
+             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -723,7 +829,8 @@ class DetailerForEachPipe:
                                       refiner_ratio=refiner_ratio, refiner_model=refiner_model,
                                       refiner_clip=refiner_clip, refiner_positive=refiner_positive, refiner_negative=refiner_negative,
                                       cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
-                                      tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                                      tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
 
         # set fallback image
         if len(cnet_pil_list) == 0:
@@ -782,6 +889,8 @@ class FaceDetailer:
                     "scheduler_func_opt": ("SCHEDULER_FUNC",),
                     "tiled_encode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                     "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
+                    "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
+                    "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                 }}
 
     RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "MASK", "DETAILER_PIPE", "IMAGE")
@@ -801,7 +910,8 @@ class FaceDetailer:
                      sam_mask_hint_use_negative, drop_size,
                      bbox_detector, segm_detector=None, sam_model_opt=None, wildcard_opt=None, detailer_hook=None,
                      refiner_ratio=None, refiner_model=None, refiner_clip=None, refiner_positive=None, refiner_negative=None, cycle=1,
-                     inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False):
+                     inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
+                     post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         # make default prompt as 'face' if empty prompt for CLIPSeg
         bbox_detector.setAux('face')
@@ -834,7 +944,8 @@ class FaceDetailer:
                                           refiner_clip=refiner_clip, refiner_positive=refiner_positive,
                                           refiner_negative=refiner_negative,
                                           cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
-                                          scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                                          scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                                      post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
         else:
             enhanced_img = image
             cropped_enhanced = []
@@ -861,7 +972,7 @@ class FaceDetailer:
              sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
              sam_mask_hint_use_negative, drop_size, bbox_detector, wildcard, cycle=1,
              sam_model_opt=None, segm_detector_opt=None, detailer_hook=None, inpaint_model=False, noise_mask_feather=0,
-             scheduler_func_opt=None, tiled_encode=False, tiled_decode=False):
+             scheduler_func_opt=None, tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         result_img = None
         result_mask = None
@@ -880,7 +991,8 @@ class FaceDetailer:
                 sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
                 sam_mask_hint_use_negative, drop_size, bbox_detector, segm_detector_opt, sam_model_opt, wildcard, detailer_hook,
                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
-                tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
 
             result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
             result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
@@ -1674,6 +1786,8 @@ class FaceDetailerPipe:
                     "scheduler_func_opt": ("SCHEDULER_FUNC",),
                     "tiled_encode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
                     "tiled_decode": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
+                    "post_detail_shrink": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled", "tooltip": "Shrink the refined patch back down before pasting it into the source image."}),
+                    "post_detail_shrink_scale": ("FLOAT", {"default": 0.995, "min": 0.10, "max": 1.0, "step": 0.001, "tooltip": "Only used when post_detail_shrink is enabled. 1.0 disables the shrink. Values below 1.0 shrink the detailed patch around the detected face center."}),
                    }
                 }
 
@@ -1691,7 +1805,7 @@ class FaceDetailerPipe:
              sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion,
              sam_mask_hint_threshold, sam_mask_hint_use_negative, drop_size, refiner_ratio=None,
              cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
-             tiled_encode=False, tiled_decode=False):
+             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         result_img = None
         result_mask = None
@@ -1715,7 +1829,8 @@ class FaceDetailerPipe:
                 refiner_ratio=refiner_ratio, refiner_model=refiner_model,
                 refiner_clip=refiner_clip, refiner_positive=refiner_positive, refiner_negative=refiner_negative,
                 cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather, scheduler_func_opt=scheduler_func_opt,
-                tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
 
             result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
             result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
@@ -1851,7 +1966,8 @@ class DetailerForEachTest(DetailerForEach):
 
     def doit(self, image, segs, model, clip, vae, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name,
              scheduler, positive, negative, denoise, feather, noise_mask, force_inpaint, wildcard, detailer_hook=None,
-             cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None, tiled_encode=False, tiled_decode=False):
+             cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
+             tiled_encode=False, tiled_decode=False, post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -1861,7 +1977,8 @@ class DetailerForEachTest(DetailerForEach):
                                       cfg, sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
                                       force_inpaint, wildcard, detailer_hook,
                                       cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
-                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                                      post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
 
         # set fallback image
         if len(cropped) == 0:
@@ -1893,7 +2010,8 @@ class DetailerForEachTestPipe(DetailerForEachPipe):
     def doit(self, image, segs, guide_size, guide_size_for, max_size, seed, steps, cfg, sampler_name, scheduler,
              denoise, feather, noise_mask, force_inpaint, basic_pipe, wildcard, cycle=1,
              refiner_ratio=None, detailer_hook=None, refiner_basic_pipe_opt=None, inpaint_model=False, noise_mask_feather=0,
-             scheduler_func_opt=None, tiled_encode=False, tiled_decode=False):
+             scheduler_func_opt=None, tiled_encode=False, tiled_decode=False,
+             post_detail_shrink=False, post_detail_shrink_scale=0.995):
 
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
@@ -1913,7 +2031,8 @@ class DetailerForEachTestPipe(DetailerForEachPipe):
                                       refiner_clip=refiner_clip, refiner_positive=refiner_positive,
                                       refiner_negative=refiner_negative,
                                       cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
-                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode)
+                                      scheduler_func_opt=scheduler_func_opt, tiled_encode=tiled_encode, tiled_decode=tiled_decode,
+                                      post_detail_shrink=post_detail_shrink, post_detail_shrink_scale=post_detail_shrink_scale)
 
         # set fallback image
         if len(cropped) == 0:

--- a/modules/impact/impact_pack.py
+++ b/modules/impact/impact_pack.py
@@ -453,13 +453,16 @@ class DetailerForEach:
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
+        logging.info(f"[Impact Pack] DetailerForEach enter image={tuple(image.shape)} segs={len(segs[1])}")
         image = image.clone()
         enhanced_alpha_list = []
         enhanced_list = []
         cropped_list = []
         cnet_pil_list = []
 
+        logging.info("[Impact Pack] DetailerForEach segs_scale_match start")
         segs = core.segs_scale_match(segs, image.shape)
+        logging.info(f"[Impact Pack] DetailerForEach segs_scale_match complete segs={len(segs[1])}")
         new_segs = []
 
         wildcard_concat_mode = None
@@ -485,13 +488,19 @@ class DetailerForEach:
             ordered_segs = segs[1]
 
         if not (isinstance(model, str) and model == "DUMMY") and noise_mask_feather > 0 and 'denoise_mask_function' not in model.model_options:
+            logging.info("[Impact Pack] DetailerForEach apply_differential_diffusion start")
             model = utils.apply_differential_diffusion(model)
+            logging.info("[Impact Pack] DetailerForEach apply_differential_diffusion complete")
 
+        image_np = image.detach().cpu().numpy()
         for i, seg in enumerate(ordered_segs):
-            cropped_image = utils.crop_ndarray4(image.cpu().numpy(), seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre crop start region={seg.crop_region} bbox={seg.bbox} label={seg.label}")
+            cropped_image = utils.crop_ndarray4(image_np, seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
             cropped_image = utils.to_tensor(cropped_image)
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask start crop={tuple(cropped_image.shape)}")
             mask = utils.to_tensor(seg.cropped_mask)
             mask = utils.tensor_gaussian_blur_mask(mask, feather)
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask complete mask={tuple(mask.shape)}")
 
             is_mask_all_zeros = (seg.cropped_mask == 0).all().item()
             if is_mask_all_zeros:
@@ -512,6 +521,7 @@ class DetailerForEach:
 
             seg_seed = seed + i if seg_seed is None else seg_seed
 
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop start")
             if not isinstance(positive, str):
                 cropped_positive = [
                     [condition, {
@@ -534,6 +544,7 @@ class DetailerForEach:
             else:
                 # Negative Conditioning is placeholder such as FLUX.1
                 cropped_negative = negative
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop complete")
 
             if wildcard_item and wildcard_item.strip() == '[SKIP]':
                 continue
@@ -698,13 +709,16 @@ class DetailerForEachAutoRetry:
         if len(image) > 1:
             raise Exception('[Impact Pack] ERROR: DetailerForEach does not allow image batches.\nPlease refer to https://github.com/ltdrdata/ComfyUI-extension-tutorials/blob/Main/ComfyUI-Impact-Pack/tutorial/batching-detailer.md for more information.')
 
+        logging.info(f"[Impact Pack] DetailerForEach enter image={tuple(image.shape)} segs={len(segs[1])}")
         image = image.clone()
         enhanced_alpha_list = []
         enhanced_list = []
         cropped_list = []
         cnet_pil_list = []
 
+        logging.info("[Impact Pack] DetailerForEach segs_scale_match start")
         segs = core.segs_scale_match(segs, image.shape)
+        logging.info(f"[Impact Pack] DetailerForEach segs_scale_match complete segs={len(segs[1])}")
         new_segs = []
 
         wildcard_concat_mode = None
@@ -730,13 +744,19 @@ class DetailerForEachAutoRetry:
             ordered_segs = segs[1]
 
         if not (isinstance(model, str) and model == "DUMMY") and noise_mask_feather > 0 and 'denoise_mask_function' not in model.model_options:
+            logging.info("[Impact Pack] DetailerForEach apply_differential_diffusion start")
             model = utils.apply_differential_diffusion(model)
+            logging.info("[Impact Pack] DetailerForEach apply_differential_diffusion complete")
 
+        image_np = image.detach().cpu().numpy()
         for i, seg in enumerate(ordered_segs):
-            cropped_image = utils.crop_ndarray4(image.cpu().numpy(), seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre crop start region={seg.crop_region} bbox={seg.bbox} label={seg.label}")
+            cropped_image = utils.crop_ndarray4(image_np, seg.crop_region)  # Never use seg.cropped_image to handle overlapping area
             cropped_image = utils.to_tensor(cropped_image)
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask start crop={tuple(cropped_image.shape)}")
             mask = utils.to_tensor(seg.cropped_mask)
             mask = utils.tensor_gaussian_blur_mask(mask, feather)
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} pre mask complete mask={tuple(mask.shape)}")
 
             is_mask_all_zeros = (seg.cropped_mask == 0).all().item()
             if is_mask_all_zeros:
@@ -757,6 +777,7 @@ class DetailerForEachAutoRetry:
 
             seg_seed = seed + i if seg_seed is None else seg_seed
 
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop start")
             if not isinstance(positive, str):
                 cropped_positive = [
                     [condition, {
@@ -779,6 +800,7 @@ class DetailerForEachAutoRetry:
             else:
                 # Negative Conditioning is placeholder such as FLUX.1
                 cropped_negative = negative
+            logging.info(f"[Impact Pack] Detailer segment {i + 1}/{len(ordered_segs)} conditioning crop complete")
 
             if wildcard_item and wildcard_item.strip() == '[SKIP]':
                 continue
@@ -1046,19 +1068,28 @@ class FaceDetailer:
                      tile_size=0, tile_overlap=0):
 
         # make default prompt as 'face' if empty prompt for CLIPSeg
+        logging.info(f"[Impact Pack] FaceDetailer bbox detect start image={tuple(image.shape)} threshold={bbox_threshold} dilation={bbox_dilation} crop_factor={bbox_crop_factor}")
         bbox_detector.setAux('face')
-        segs = bbox_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor, drop_size, detailer_hook=detailer_hook)
-        bbox_detector.setAux(None)
+        try:
+            segs = bbox_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor, drop_size, detailer_hook=detailer_hook)
+        finally:
+            bbox_detector.setAux(None)
+        logging.info(f"[Impact Pack] FaceDetailer bbox detect complete segs={len(segs[1])}")
 
         # bbox + sam combination
         if sam_model_opt is not None:
+            logging.info(f"[Impact Pack] FaceDetailer SAM refinement start segs={len(segs[1])}")
             sam_mask = core.make_sam_mask(sam_model_opt, segs, image, sam_detection_hint, sam_dilation,
                                           sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
                                           sam_mask_hint_use_negative, )
+            logging.info(f"[Impact Pack] FaceDetailer SAM refinement mask complete shape={tuple(sam_mask.shape)}")
             segs = core.segs_bitwise_and_mask(segs, sam_mask)
+            logging.info(f"[Impact Pack] FaceDetailer SAM refinement complete segs={len(segs[1])}")
 
         elif segm_detector is not None:
+            logging.info(f"[Impact Pack] FaceDetailer segm refinement start segs={len(segs[1])}")
             segm_segs = segm_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor, drop_size)
+            logging.info(f"[Impact Pack] FaceDetailer segm detector complete segs={len(segm_segs[1])}")
 
             if (hasattr(segm_detector, 'override_bbox_by_segm') and segm_detector.override_bbox_by_segm and
                     not (detailer_hook is not None and not hasattr(detailer_hook, 'override_bbox_by_segm'))):
@@ -1066,9 +1097,11 @@ class FaceDetailer:
             else:
                 segm_mask = core.segs_to_combined_mask(segm_segs)
                 segs = core.segs_bitwise_and_mask(segs, segm_mask)
+            logging.info(f"[Impact Pack] FaceDetailer segm refinement complete segs={len(segs[1])}")
 
         mask_segs = segs
         if len(segs[1]) > 0:
+            logging.info(f"[Impact Pack] FaceDetailer detail pass start segs={len(segs[1])}")
             enhanced_img, _, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list, new_segs = \
                 DetailerForEach.do_detail(image, segs, model, clip, vae, guide_size, guide_size_for_bbox, max_size, seed, steps, cfg,
                                           sampler_name, scheduler, positive, negative, denoise, feather, noise_mask,
@@ -1082,7 +1115,9 @@ class FaceDetailer:
                                           auto_vae_tiled_encode=force_adaptive_tiled_encode,
                                           vae_tile_size=tile_size, vae_tile_overlap=tile_overlap)
             mask_segs = new_segs
+            logging.info(f"[Impact Pack] FaceDetailer detail pass complete new_segs={len(new_segs[1])}")
         else:
+            logging.info("[Impact Pack] FaceDetailer detail pass skipped: no segs")
             enhanced_img = image
             cropped_enhanced = []
             cropped_enhanced_alpha = []

--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -508,6 +508,36 @@ def find_input_value(input_node, prompt, input_type=int, input_keys=('value',)):
     return input_val
 
 
+def resolve_wildcard_text_input(value, prompt):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list) and len(value):
+        try:
+            input_node = prompt[value[0]]
+            return find_input_value(
+                input_node,
+                prompt=prompt,
+                input_type=str,
+                input_keys=(
+                    'text',
+                    'wildcard_text',
+                    'populated_text',
+                    'positive',
+                    'positive_prompt',
+                    'positive_prompt_template',
+                    'negative',
+                    'negative_prompt',
+                    'negative_prompt_template',
+                    'string',
+                    'value',
+                    'prompt',
+                ),
+            )
+        except Exception as e:
+            logging.warning(f"[Impact Pack] Error resolving wildcard text input - {e}")
+    return None
+
+
 def onprompt_populate_wildcards(json_data):
     prompt = json_data['prompt']
 
@@ -547,7 +577,14 @@ def onprompt_populate_wildcards(json_data):
                 else:
                     input_seed = int(inputs['seed'])
 
-                inputs['populated_text'] = impact.wildcards.process(inputs['wildcard_text'], input_seed)
+                wildcard_text = resolve_wildcard_text_input(inputs.get('wildcard_text'), prompt)
+                if wildcard_text is None and isinstance(inputs.get('populated_text'), str):
+                    wildcard_text = inputs['populated_text']
+                if wildcard_text is None:
+                    logging.info(f"[Impact Pack] Could not resolve wildcard_text for '{v['class_type']}'. It will be ignored.")
+                    continue
+
+                inputs['populated_text'] = impact.wildcards.process(wildcard_text, input_seed)
                 inputs['mode'] = 'reproduce'
 
                 PromptServer.instance.send_sync("impact-node-feedback", {"node_id": k, "widget_name": "populated_text", "type": "STRING", "value": inputs['populated_text']})

--- a/modules/impact/impact_server.py
+++ b/modules/impact/impact_server.py
@@ -533,7 +533,7 @@ def resolve_wildcard_text_input(value, prompt):
                     'prompt',
                 ),
             )
-        except Exception as e:
+        except (KeyError, AttributeError, TypeError, IndexError) as e:
             logging.warning(f"[Impact Pack] Error resolving wildcard text input - {e}")
     return None
 
@@ -577,7 +577,10 @@ def onprompt_populate_wildcards(json_data):
                 else:
                     input_seed = int(inputs['seed'])
 
-                wildcard_text = resolve_wildcard_text_input(inputs.get('wildcard_text'), prompt)
+                raw_wildcard_text = inputs.get('wildcard_text')
+                wildcard_text = resolve_wildcard_text_input(raw_wildcard_text, prompt)
+                if wildcard_text is None and raw_wildcard_text is not None and not isinstance(raw_wildcard_text, str):
+                    logging.warning(f"[Impact Pack] Could not resolve linked wildcard_text for '{v['class_type']}' node {k}; falling back to populated_text.")
                 if wildcard_text is None and isinstance(inputs.get('populated_text'), str):
                     wildcard_text = inputs['populated_text']
                 if wildcard_text is None:

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -185,62 +185,21 @@ def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     # PIL.Image.resize can terminate the interpreter with SIGFPE/SIGSEGV in native
     # code for some resize inputs. That cannot be recovered with try/except, so the
     # detailer path must avoid PIL for tensor resizing entirely.
-    #
-    # Large CPU bicubic/linear resizes can still wedge in WSL/PyTorch builds. For
-    # RGB/RGBA image tensors, run large resizes on CUDA when available and then
-    # return to the caller's original device/dtype. Masks and tiny tensors stay on
-    # their original device to avoid unnecessary CUDA churn.
-    work_device = original_device
-    use_cuda_resize = False
-    max_pixels = max(int(cur_w) * int(cur_h), int(w) * int(h))
-    if (
-        original_device.type == "cpu"
-        and image.shape[-1] >= 3
-        and max_pixels >= 512 * 512
-        and torch.cuda.is_available()
-    ):
-        work_device = torch.device("cuda")
-        use_cuda_resize = True
-        logging.info(
-            f"Detailer: tensor_resize using CUDA for large {mode} resize "
-            f"{(cur_w, cur_h)} -> {(w, h)}"
-        )
+    nchw = image.movedim(-1, 1).contiguous().to(dtype=torch.float32)
 
-    def resize_on_device(device):
-        nchw = image.to(device=device, dtype=torch.float32, non_blocking=False).movedim(-1, 1).contiguous()
-
-        if mode in ("bilinear", "bicubic"):
-            return torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode, align_corners=False)
-        elif mode in ("nearest", "area"):
-            return torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode)
-        else:
-            raise ValueError(f"Unsupported resize mode: {mode}")
-
-    try:
-        resized = resize_on_device(work_device)
-    except RuntimeError as e:
-        if not use_cuda_resize:
-            raise
-
-        logging.warning(
-            f"Detailer: CUDA resize fallback to CPU after {mode} resize failure "
-            f"{(cur_w, cur_h)} -> {(w, h)}: {e}"
-        )
-        try:
-            torch.cuda.empty_cache()
-        except Exception:
-            pass
-        resized = resize_on_device(original_device)
-
-    if resized.is_cuda:
-        torch.cuda.synchronize(resized.device)
+    if mode in ("bilinear", "bicubic"):
+        resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode, align_corners=False)
+    elif mode in ("nearest", "area"):
+        resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode)
+    else:
+        raise ValueError(f"Unsupported resize mode: {mode}")
 
     resized = resized.movedim(1, -1).contiguous()
 
     if image.shape[-1] >= 3:
         resized = resized.clamp(0.0, 1.0)
 
-    return resized.to(device=original_device, dtype=original_dtype, non_blocking=False)
+    return resized.to(device=original_device, dtype=original_dtype)
 
 
 # Kept for compatibility with callers/imports, but tensor_resize no longer uses
@@ -294,10 +253,10 @@ def tensor_resize_for_detailer_output(image, w: int, h: int):
         logging.info(f"Detailer: correcting post-decode padding by crop/pad {(cur_w, cur_h)} -> {(w, h)}")
         return tensor_center_crop_or_pad(image, w, h)
 
-    # Use area only for true downscale. For upscaling the decoded detailer crop
-    # back to paste geometry, use bicubic to avoid the visible softness introduced
-    # by the previous bilinear safety path. PIL is still avoided; this is torch.
-    mode = "area" if w <= cur_w and h <= cur_h else "bicubic"
+    # For final paste-back geometry, prefer area for downscale and bilinear for
+    # upscale. Avoid bicubic here: this path has already been observed to crash
+    # or wedge in native resize code after VAE decode.
+    mode = "area" if w <= cur_w and h <= cur_h else "bilinear"
     logging.info(f"Detailer: post-decode resize {(cur_w, cur_h)} -> {(w, h)} using torch {mode} on {image.device}")
     return general_tensor_resize(image, w, h, mode=mode)
 

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -31,7 +31,7 @@ def tensor_convert_rgba(image, prefer_copy=True):
         return image
 
     if n_channel == 3:
-        alpha = torch.ones((*image.shape[:-1], 1))
+        alpha = torch.ones((*image.shape[:-1], 1), device=image.device, dtype=image.dtype)
         return torch.cat((image, alpha), axis=-1)
 
     if n_channel == 1:
@@ -211,6 +211,56 @@ def tensor_resize(image, w: int, h: int):
     return general_tensor_resize(image, w, h, mode=mode)
 
 
+def tensor_center_crop_or_pad(image, w: int, h: int):
+    _tensor_check_image(image)
+    w = int(w)
+    h = int(h)
+    if w <= 0 or h <= 0:
+        raise ValueError(f"Invalid crop/pad target: {(w, h)}")
+
+    _, cur_h, cur_w, channels = image.shape
+    if cur_w == w and cur_h == h:
+        return image
+
+    src_x0 = max((cur_w - w) // 2, 0)
+    src_y0 = max((cur_h - h) // 2, 0)
+    dst_x0 = max((w - cur_w) // 2, 0)
+    dst_y0 = max((h - cur_h) // 2, 0)
+    copy_w = min(cur_w, w)
+    copy_h = min(cur_h, h)
+
+    out = torch.zeros((image.shape[0], h, w, channels), device=image.device, dtype=image.dtype)
+    out[:, dst_y0:dst_y0 + copy_h, dst_x0:dst_x0 + copy_w, :] = image[:, src_y0:src_y0 + copy_h, src_x0:src_x0 + copy_w, :]
+    return out
+
+
+def tensor_resize_for_detailer_output(image, w: int, h: int):
+    _tensor_check_image(image)
+    w = int(w)
+    h = int(h)
+    if w <= 0 or h <= 0:
+        raise ValueError(f"Invalid detailer resize target: {(w, h)}")
+
+    cur_w, cur_h = tensor_get_size(image)
+    if cur_w == w and cur_h == h:
+        return image
+
+    # VAEs often produce dimensions rounded to latent/tile multiples. When the
+    # difference is only a small padding margin, do not run interpolation at all:
+    # crop/pad the tensor directly. This avoids a native/PyTorch resize path at
+    # the most fragile post-decode boundary.
+    if abs(cur_w - w) <= 16 and abs(cur_h - h) <= 16:
+        logging.info(f"Detailer: correcting post-decode padding by crop/pad {(cur_w, cur_h)} -> {(w, h)}")
+        return tensor_center_crop_or_pad(image, w, h)
+
+    # For final paste-back geometry, prefer area for downscale and bilinear for
+    # upscale. Avoid bicubic here: this path has already been observed to crash
+    # or wedge in native resize code after VAE decode.
+    mode = "area" if w <= cur_w and h <= cur_h else "bilinear"
+    logging.info(f"Detailer: post-decode resize {(cur_w, cur_h)} -> {(w, h)} using torch {mode} on {image.device}")
+    return general_tensor_resize(image, w, h, mode=mode)
+
+
 def tensor_get_size(image):
     """Mimicking `PIL.Image.size`"""
     _tensor_check_image(image)
@@ -296,6 +346,10 @@ def tensor_paste(image1, image2, left_top, mask):
     """
     Pastes image2 onto image1 at position left_top using mask.
     Supports both RGB and RGBA images.
+
+    Large paste regions are processed in horizontal chunks to avoid allocating
+    full-frame blend temporaries for FaceDetailer crops that cover most of the
+    image.
     """
     _tensor_check_image(image1)
     _tensor_check_image(image2)
@@ -308,58 +362,57 @@ def tensor_paste(image1, image2, left_top, mask):
     _, h1, w1, c1 = image1.shape
     _, h2, w2, c2 = image2.shape
 
-    # Calculate image patch size
     w = min(w1, x + w2) - x
     h = min(h1, y + h2) - y
 
-    # If the patch is out of bound, nothing to do!
     if w <= 0 or h <= 0:
         return
 
     mask = mask[:, :h, :w, :]
 
-    # Get the region to be modified
-    region1 = image1[:, y:y+h, x:x+w, :]
-    region2 = image2[:, :h, :w, :]
+    pixels = int(w) * int(h)
+    if pixels >= 4_000_000:
+        rows_per_chunk = max(64, min(512, 8_000_000 // max(int(w), 1)))
+        logging.info(f"Detailer: tensor_paste chunked region {(w, h)} rows_per_chunk={rows_per_chunk}")
+    else:
+        rows_per_chunk = h
 
-    # Handle RGB and RGBA cases
-    if c1 == 3 and c2 == 3:
-        # Both RGB - simple case
-        image1[:, y:y+h, x:x+w, :] = (1 - mask) * region1 + mask * region2
+    for y0 in range(0, h, rows_per_chunk):
+        y1 = min(y0 + rows_per_chunk, h)
+        dst_y0 = y + y0
+        dst_y1 = y + y1
 
-    elif c1 == 4 and c2 == 4:
-        # Both RGBA - need to handle alpha channel separately
-        # RGB channels
-        image1[:, y:y+h, x:x+w, :3] = (
-            (1 - mask) * region1[:, :, :, :3] +
-            mask * region2[:, :, :, :3]
-        )
+        mask_chunk = mask[:, y0:y1, :, :]
+        region1 = image1[:, dst_y0:dst_y1, x:x+w, :]
+        region2 = image2[:, y0:y1, :w, :]
 
-        # Alpha channel - use "over" composition
-        a1 = region1[:, :, :, 3:4]
-        a2 = region2[:, :, :, 3:4] * mask
-        new_alpha = a1 + a2 * (1 - a1)
-        image1[:, y:y+h, x:x+w, 3:4] = new_alpha
+        if c1 == 3 and c2 == 3:
+            image1[:, dst_y0:dst_y1, x:x+w, :] = (1 - mask_chunk) * region1 + mask_chunk * region2
 
-    elif c1 == 4 and c2 == 3:
-        # Target is RGBA, source is RGB - assume source is fully opaque
-        image1[:, y:y+h, x:x+w, :3] = (
-            (1 - mask) * region1[:, :, :, :3] +
-            mask * region2
-        )
-        # Alpha channel - reduce alpha where mask is applied
-        image1[:, y:y+h, x:x+w, 3:4] = region1[:, :, :, 3:4] * (1 - mask) + mask
+        elif c1 == 4 and c2 == 4:
+            image1[:, dst_y0:dst_y1, x:x+w, :3] = (
+                (1 - mask_chunk) * region1[:, :, :, :3] +
+                mask_chunk * region2[:, :, :, :3]
+            )
+            a1 = region1[:, :, :, 3:4]
+            a2 = region2[:, :, :, 3:4] * mask_chunk
+            image1[:, dst_y0:dst_y1, x:x+w, 3:4] = a1 + a2 * (1 - a1)
 
-    elif c1 == 3 and c2 == 4:
-        # Target is RGB, source is RGBA - apply source alpha to mask
-        effective_mask = mask * region2[:, :, :, 3:4]
-        image1[:, y:y+h, x:x+w, :] = (
-            (1 - effective_mask) * region1 +
-            effective_mask * region2[:, :, :, :3]
-        )
+        elif c1 == 4 and c2 == 3:
+            image1[:, dst_y0:dst_y1, x:x+w, :3] = (
+                (1 - mask_chunk) * region1[:, :, :, :3] +
+                mask_chunk * region2
+            )
+            image1[:, dst_y0:dst_y1, x:x+w, 3:4] = region1[:, :, :, 3:4] * (1 - mask_chunk) + mask_chunk
+
+        elif c1 == 3 and c2 == 4:
+            effective_mask = mask_chunk * region2[:, :, :, 3:4]
+            image1[:, dst_y0:dst_y1, x:x+w, :] = (
+                (1 - effective_mask) * region1 +
+                effective_mask * region2[:, :, :, :3]
+            )
 
     return
-
 
 def center_of_bbox(bbox):
     w, h = bbox[2] - bbox[0], bbox[3] - bbox[1]

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -94,6 +94,55 @@ def remove_padding(image, padding):
     return image[:, pad_top:image.shape[1] - pad_bottom, pad_left:image.shape[2] - pad_right, :]
 
 
+def shift_within_canvas(data, shift_x, shift_y, canvas_w=None, canvas_h=None, fill_value=0.0):
+    is_torch = isinstance(data, torch.Tensor)
+    data_device = data.device if is_torch else None
+    data_dtype = data.dtype if is_torch else None
+    np_data = data.detach().cpu().numpy() if is_torch else np.asarray(data)
+
+    if np_data.ndim not in (2, 3, 4):
+        raise ValueError(f"Unsupported ndim for shift_within_canvas: {np_data.ndim}")
+
+    if np_data.ndim == 4:
+        _, src_h, src_w, _ = np_data.shape
+    elif np_data.ndim == 3:
+        _, src_h, src_w = np_data.shape
+    else:
+        src_h, src_w = np_data.shape
+
+    canvas_w = src_w if canvas_w is None else int(canvas_w)
+    canvas_h = src_h if canvas_h is None else int(canvas_h)
+
+    if np_data.ndim == 4:
+        out_shape = (np_data.shape[0], canvas_h, canvas_w, np_data.shape[3])
+    elif np_data.ndim == 3:
+        out_shape = (np_data.shape[0], canvas_h, canvas_w)
+    else:
+        out_shape = (canvas_h, canvas_w)
+    result = np.full(out_shape, fill_value, dtype=np_data.dtype)
+
+    dst_x1 = max(0, int(shift_x))
+    dst_y1 = max(0, int(shift_y))
+    src_x1 = max(0, -int(shift_x))
+    src_y1 = max(0, -int(shift_y))
+
+    copy_w = min(src_w - src_x1, canvas_w - dst_x1)
+    copy_h = min(src_h - src_y1, canvas_h - dst_y1)
+
+    if copy_w > 0 and copy_h > 0:
+        if np_data.ndim == 4:
+            result[:, dst_y1:dst_y1 + copy_h, dst_x1:dst_x1 + copy_w, :] = np_data[:, src_y1:src_y1 + copy_h, src_x1:src_x1 + copy_w, :]
+        elif np_data.ndim == 3:
+            result[:, dst_y1:dst_y1 + copy_h, dst_x1:dst_x1 + copy_w] = np_data[:, src_y1:src_y1 + copy_h, src_x1:src_x1 + copy_w]
+        else:
+            result[dst_y1:dst_y1 + copy_h, dst_x1:dst_x1 + copy_w] = np_data[src_y1:src_y1 + copy_h, src_x1:src_x1 + copy_w]
+
+    if is_torch:
+        result = torch.from_numpy(result).to(device=data_device, dtype=data_dtype)
+
+    return result
+
+
 def adjust_bbox_after_resize(bbox, original_size, target_size, padding):
     """
     bbox: (x1, y1, x2, y2) in original image

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -561,7 +561,13 @@ def _gaussian_kernel(kernel_size, sigma):
 
 
 def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
-    """Return NHWC torch.Tenser from ndim == 2 or 4 `np.ndarray` or `torch.Tensor`"""
+    """Return NHWC torch.Tensor from ndim == 2/3/4 mask data.
+
+    Blur on the mask's current device. The old code called
+    ``mask.to(comfy.model_management.get_torch_device())`` without using the
+    returned tensor, which could still create a transient CUDA copy before the
+    detailer reached its first resize/model-load log.
+    """
     if isinstance(mask, np.ndarray):
         mask = torch.from_numpy(mask)
 
@@ -575,26 +581,54 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
     if kernel_size <= 0:
         return mask
 
-    kernel_size = kernel_size*2+1
+    kernel_size = kernel_size * 2 + 1
 
     shortest = min(mask.shape[1], mask.shape[2])
     if shortest <= kernel_size:
-        kernel_size = int(shortest/2)
+        kernel_size = int(shortest / 2)
         if kernel_size % 2 == 0:
             kernel_size += 1
         if kernel_size < 3:
             return mask  # skip feathering
 
     prev_device = mask.device
-    device = comfy.model_management.get_torch_device()
-    mask.to(device)
+    prev_dtype = mask.dtype
+    work_device = prev_device
+    blur_trace = format(id(mask) & 0xfffffff, "x")
+    blur_start = time.perf_counter()
 
-    # apply gaussian blur
-    mask = mask[:, None, ..., 0]
-    blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=kernel_size, sigma=sigma)(mask)
+    logging.info(
+        "[Impact Pack] tensor_gaussian_blur_mask[%s] start "
+        f"shape={tuple(mask.shape)} kernel={kernel_size} sigma={sigma} "
+        f"device={prev_device} work_device={work_device}",
+        blur_trace
+    )
+
+    mask_work = mask.to(device=work_device, dtype=torch.float32, copy=False)
+
+    # torchvision GaussianBlur handles NCHW tensors and avoids the broken
+    # previous unassigned .to(...) calls. Keep the output shape NHWC.
+    mask_nchw = mask_work[:, None, ..., 0]
+    try:
+        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=kernel_size, sigma=sigma)(mask_nchw)
+    except Exception:
+        if mask_nchw.device.type == "cpu":
+            raise
+        logging.warning(
+            "[Impact Pack] tensor_gaussian_blur_mask[%s] failed on device=%s; retrying on cpu",
+            blur_trace, mask_nchw.device, exc_info=True
+        )
+        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=kernel_size, sigma=sigma)(mask_nchw.cpu())
     blurred_mask = blurred_mask[:, 0, ..., None]
 
-    blurred_mask.to(prev_device)
+    if blurred_mask.device != prev_device or blurred_mask.dtype != prev_dtype:
+        blurred_mask = blurred_mask.to(device=prev_device, dtype=prev_dtype, copy=False)
+
+    logging.info(
+        "[Impact Pack] tensor_gaussian_blur_mask[%s] complete "
+        f"shape={tuple(blurred_mask.shape)} device={blurred_mask.device} elapsed={time.perf_counter() - blur_start:.3f}s",
+        blur_trace
+    )
 
     return blurred_mask
 

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -648,14 +648,14 @@ def crop_image(image, crop_region):
     return crop_tensor4(image, crop_region)
 
 
-def to_latent_image(pixels, vae, vae_tiled_encode=False, auto_vae_tiled_encode=False):
+def to_latent_image(pixels, vae, vae_tiled_encode=False, auto_vae_tiled_encode=False, tile_size=0, overlap=0):
     x = pixels.shape[1]
     y = pixels.shape[2]
     if pixels.shape[1] != x or pixels.shape[2] != y:
         pixels = pixels[:, :x, :y, :]
 
     start = time.time()
-    tile_size, overlap = get_vae_tiled_encode_settings(pixels)
+    tile_size, overlap = get_vae_tiled_encode_settings(pixels, tile_size=tile_size, overlap=overlap)
     force_low_memory_tiling = tile_size < 512
     should_tile = vae_tiled_encode or auto_vae_tiled_encode or force_low_memory_tiling
 
@@ -679,7 +679,7 @@ def to_latent_image(pixels, vae, vae_tiled_encode=False, auto_vae_tiled_encode=F
     return encoded
 
 
-def get_vae_tiled_encode_settings(pixels):
+def get_vae_tiled_encode_settings(pixels, tile_size=0, overlap=0):
     h = int(pixels.shape[1])
     w = int(pixels.shape[2])
     megapixels = (h * w) / 1_000_000.0
@@ -693,8 +693,21 @@ def get_vae_tiled_encode_settings(pixels):
     else:
         tile_size = 512
 
-    overlap = max(16, tile_size // 8)
-    return tile_size, overlap
+    resolved_tile_size = int(tile_size) if tile_size is not None else 0
+    if resolved_tile_size <= 0:
+        if megapixels >= 3.0:
+            resolved_tile_size = 128
+        elif megapixels >= 1.5:
+            resolved_tile_size = 256
+        else:
+            resolved_tile_size = 512
+
+    resolved_overlap = int(overlap) if overlap is not None else 0
+    if resolved_overlap <= 0:
+        resolved_overlap = max(16, resolved_tile_size // 8)
+
+    resolved_overlap = min(max(0, resolved_overlap), max(0, resolved_tile_size - 1))
+    return resolved_tile_size, resolved_overlap
 
 
 def empty_pil_tensor(w=64, h=64):

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -202,11 +202,7 @@ def _tensor_resize_cpu_opencv(image, w: int, h: int, mode="bilinear"):
     interpolation = _cv2_interpolation_for_mode(mode)
     original_dtype = image.dtype
 
-    np_image = image.detach().contiguous().cpu().numpy()
-    if np_image.dtype != np.float32:
-        np_work = np_image.astype(np.float32, copy=False)
-    else:
-        np_work = np_image
+    np_work = image.detach().to(dtype=torch.float32).contiguous().cpu().numpy()
 
     batch, _, _, channels = np_work.shape
     resized_np = np.empty((batch, h, w, channels), dtype=np.float32)

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -191,6 +191,7 @@ def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     # return to the caller's original device/dtype. Masks and tiny tensors stay on
     # their original device to avoid unnecessary CUDA churn.
     work_device = original_device
+    use_cuda_resize = False
     max_pixels = max(int(cur_w) * int(cur_h), int(w) * int(h))
     if (
         original_device.type == "cpu"
@@ -199,19 +200,37 @@ def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
         and torch.cuda.is_available()
     ):
         work_device = torch.device("cuda")
+        use_cuda_resize = True
         logging.info(
             f"Detailer: tensor_resize using CUDA for large {mode} resize "
             f"{(cur_w, cur_h)} -> {(w, h)}"
         )
 
-    nchw = image.to(device=work_device, dtype=torch.float32, non_blocking=False).movedim(-1, 1).contiguous()
+    def resize_on_device(device):
+        nchw = image.to(device=device, dtype=torch.float32, non_blocking=False).movedim(-1, 1).contiguous()
 
-    if mode in ("bilinear", "bicubic"):
-        resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode, align_corners=False)
-    elif mode in ("nearest", "area"):
-        resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode)
-    else:
-        raise ValueError(f"Unsupported resize mode: {mode}")
+        if mode in ("bilinear", "bicubic"):
+            return torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode, align_corners=False)
+        elif mode in ("nearest", "area"):
+            return torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode)
+        else:
+            raise ValueError(f"Unsupported resize mode: {mode}")
+
+    try:
+        resized = resize_on_device(work_device)
+    except RuntimeError as e:
+        if not use_cuda_resize:
+            raise
+
+        logging.warning(
+            f"Detailer: CUDA resize fallback to CPU after {mode} resize failure "
+            f"{(cur_w, cur_h)} -> {(w, h)}: {e}"
+        )
+        try:
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+        resized = resize_on_device(original_device)
 
     if resized.is_cuda:
         torch.cuda.synchronize(resized.device)

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -185,7 +185,26 @@ def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     # PIL.Image.resize can terminate the interpreter with SIGFPE/SIGSEGV in native
     # code for some resize inputs. That cannot be recovered with try/except, so the
     # detailer path must avoid PIL for tensor resizing entirely.
-    nchw = image.movedim(-1, 1).contiguous().to(dtype=torch.float32)
+    #
+    # Large CPU bicubic/linear resizes can still wedge in WSL/PyTorch builds. For
+    # RGB/RGBA image tensors, run large resizes on CUDA when available and then
+    # return to the caller's original device/dtype. Masks and tiny tensors stay on
+    # their original device to avoid unnecessary CUDA churn.
+    work_device = original_device
+    max_pixels = max(int(cur_w) * int(cur_h), int(w) * int(h))
+    if (
+        original_device.type == "cpu"
+        and image.shape[-1] >= 3
+        and max_pixels >= 512 * 512
+        and torch.cuda.is_available()
+    ):
+        work_device = torch.device("cuda")
+        logging.info(
+            f"Detailer: tensor_resize using CUDA for large {mode} resize "
+            f"{(cur_w, cur_h)} -> {(w, h)}"
+        )
+
+    nchw = image.to(device=work_device, dtype=torch.float32, non_blocking=False).movedim(-1, 1).contiguous()
 
     if mode in ("bilinear", "bicubic"):
         resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode, align_corners=False)
@@ -194,12 +213,15 @@ def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     else:
         raise ValueError(f"Unsupported resize mode: {mode}")
 
+    if resized.is_cuda:
+        torch.cuda.synchronize(resized.device)
+
     resized = resized.movedim(1, -1).contiguous()
 
     if image.shape[-1] >= 3:
         resized = resized.clamp(0.0, 1.0)
 
-    return resized.to(device=original_device, dtype=original_dtype)
+    return resized.to(device=original_device, dtype=original_dtype, non_blocking=False)
 
 
 # Kept for compatibility with callers/imports, but tensor_resize no longer uses
@@ -253,10 +275,10 @@ def tensor_resize_for_detailer_output(image, w: int, h: int):
         logging.info(f"Detailer: correcting post-decode padding by crop/pad {(cur_w, cur_h)} -> {(w, h)}")
         return tensor_center_crop_or_pad(image, w, h)
 
-    # For final paste-back geometry, prefer area for downscale and bilinear for
-    # upscale. Avoid bicubic here: this path has already been observed to crash
-    # or wedge in native resize code after VAE decode.
-    mode = "area" if w <= cur_w and h <= cur_h else "bilinear"
+    # Use area only for true downscale. For upscaling the decoded detailer crop
+    # back to paste geometry, use bicubic to avoid the visible softness introduced
+    # by the previous bilinear safety path. PIL is still avoided; this is torch.
+    mode = "area" if w <= cur_w and h <= cur_h else "bicubic"
     logging.info(f"Detailer: post-decode resize {(cur_w, cur_h)} -> {(w, h)} using torch {mode} on {image.device}")
     return general_tensor_resize(image, w, h, mode=mode)
 

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -654,14 +654,35 @@ def to_latent_image(pixels, vae, vae_tiled_encode=False):
         pixels = pixels[:, :x, :y, :]
 
     start = time.time()
-    if vae_tiled_encode:
-        encoded = nodes.VAEEncodeTiled().encode(vae, pixels, 512, overlap=64)[0] # using default settings
-        logging.info(f"[Impact Pack] vae encoded (tiled) in {time.time() - start:.1f}s")
+    tile_size, overlap = get_vae_tiled_encode_settings(pixels)
+    force_low_memory_tiling = tile_size < 512
+
+    if vae_tiled_encode or force_low_memory_tiling:
+        encoded = nodes.VAEEncodeTiled().encode(vae, pixels, tile_size, overlap=overlap)[0]
+        logging.info(f"[Impact Pack] vae encoded (tiled {tile_size}/{overlap}) in {time.time() - start:.1f}s")
     else:
         encoded = nodes.VAEEncode().encode(vae, pixels)[0]
         logging.info(f"[Impact Pack] vae encoded in {time.time() - start:.1f}s")
 
     return encoded
+
+
+def get_vae_tiled_encode_settings(pixels):
+    h = int(pixels.shape[1])
+    w = int(pixels.shape[2])
+    megapixels = (h * w) / 1_000_000.0
+
+    # FaceDetailer crops at/above ~1.5MP have shown sustained VAE encode pressure
+    # with 512px tiles; step down further past ~3MP to protect VRAM headroom.
+    if megapixels >= 3.0:
+        tile_size = 128
+    elif megapixels >= 1.5:
+        tile_size = 256
+    else:
+        tile_size = 512
+
+    overlap = max(16, tile_size // 8)
+    return tile_size, overlap
 
 
 def empty_pil_tensor(w=64, h=64):

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -686,13 +686,6 @@ def get_vae_tiled_encode_settings(pixels, tile_size=0, overlap=0):
 
     # FaceDetailer encode should stay on the tiled path once selected; the tile
     # geometry adapts by crop size, but 512/64 is still the tiled path.
-    if megapixels >= 3.0:
-        tile_size = 128
-    elif megapixels >= 1.5:
-        tile_size = 256
-    else:
-        tile_size = 512
-
     resolved_tile_size = int(tile_size) if tile_size is not None else 0
     if resolved_tile_size <= 0:
         if megapixels >= 3.0:

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -657,7 +657,7 @@ def to_latent_image(pixels, vae, vae_tiled_encode=False, auto_vae_tiled_encode=F
     start = time.time()
     tile_size, overlap = get_vae_tiled_encode_settings(pixels, tile_size=tile_size, overlap=overlap)
     force_low_memory_tiling = tile_size < 512
-    should_tile = vae_tiled_encode or auto_vae_tiled_encode or force_low_memory_tiling
+    should_tile = vae_tiled_encode or auto_vae_tiled_encode or force_low_memory_tiling or tile_size > 0 or overlap > 0
 
     if should_tile:
         encoder = nodes.VAEEncodeTiled()

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -166,6 +166,63 @@ def adjust_bbox_after_resize(bbox, original_size, target_size, padding):
     return x1, y1, x2, y2
 
 
+def _cv2_interpolation_for_mode(mode):
+    if mode == "nearest":
+        return cv2.INTER_NEAREST
+    if mode == "area":
+        return cv2.INTER_AREA
+    if mode == "bicubic":
+        return cv2.INTER_CUBIC
+    if mode == "bilinear":
+        return cv2.INTER_LINEAR
+    raise ValueError(f"Unsupported resize mode: {mode}")
+
+
+def _tensor_resize_cpu_opencv(image, w: int, h: int, mode="bilinear"):
+    """Resize BHWC CPU tensors through OpenCV instead of torch interpolate.
+
+    The detailer path can hit this with medium/large CPU IMAGE tensors after a
+    long CUDA-heavy workflow. Avoiding torch's CPU interpolate/threadpool here
+    removes another native wedge point while preserving the BHWC tensor contract.
+    """
+    _tensor_check_image(image)
+
+    if image.device.type != "cpu":
+        raise ValueError("_tensor_resize_cpu_opencv expects a CPU tensor")
+
+    w = int(w)
+    h = int(h)
+    if w <= 0 or h <= 0:
+        raise ValueError(f"Invalid resize target: {(w, h)}")
+
+    cur_w, cur_h = tensor_get_size(image)
+    if cur_w == w and cur_h == h:
+        return image
+
+    interpolation = _cv2_interpolation_for_mode(mode)
+    original_dtype = image.dtype
+
+    np_image = image.detach().contiguous().cpu().numpy()
+    if np_image.dtype != np.float32:
+        np_work = np_image.astype(np.float32, copy=False)
+    else:
+        np_work = np_image
+
+    batch, _, _, channels = np_work.shape
+    resized_np = np.empty((batch, h, w, channels), dtype=np.float32)
+
+    for i in range(batch):
+        resized_frame = cv2.resize(np_work[i], (w, h), interpolation=interpolation)
+        if channels == 1 and resized_frame.ndim == 2:
+            resized_frame = resized_frame[..., None]
+        resized_np[i] = resized_frame
+
+    if channels in (3, 4):
+        np.clip(resized_np, 0.0, 1.0, out=resized_np)
+
+    return torch.from_numpy(resized_np).to(dtype=original_dtype)
+
+
 def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     _tensor_check_image(image)
     w = int(w)
@@ -180,11 +237,12 @@ def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     original_device = image.device
     original_dtype = image.dtype
 
-    # Resize directly with torch instead of round-tripping through PIL.
-    #
-    # PIL.Image.resize can terminate the interpreter with SIGFPE/SIGSEGV in native
-    # code for some resize inputs. That cannot be recovered with try/except, so the
-    # detailer path must avoid PIL for tensor resizing entirely.
+    if original_device.type == "cpu":
+        return _tensor_resize_cpu_opencv(image, w, h, mode=mode)
+
+    # CUDA/non-CPU tensors stay on the existing torch path. This preserves the
+    # current behavior for model/device-resident callers while removing torch CPU
+    # interpolate from the FaceDetailer CPU image path.
     nchw = image.movedim(-1, 1).contiguous().to(dtype=torch.float32)
 
     if mode in ("bilinear", "bicubic"):
@@ -257,7 +315,7 @@ def tensor_resize_for_detailer_output(image, w: int, h: int):
     # upscale. Avoid bicubic here: this path has already been observed to crash
     # or wedge in native resize code after VAE decode.
     mode = "area" if w <= cur_w and h <= cur_h else "bilinear"
-    logging.info(f"Detailer: post-decode resize {(cur_w, cur_h)} -> {(w, h)} using torch {mode} on {image.device}")
+    logging.info(f"Detailer: post-decode resize {(cur_w, cur_h)} -> {(w, h)} using {mode} on {image.device}")
     return general_tensor_resize(image, w, h, mode=mode)
 
 

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -656,7 +656,8 @@ def to_latent_image(pixels, vae, vae_tiled_encode=False, auto_vae_tiled_encode=F
 
     start = time.time()
     tile_size, overlap = get_vae_tiled_encode_settings(pixels)
-    should_tile = vae_tiled_encode or auto_vae_tiled_encode
+    force_low_memory_tiling = tile_size < 512
+    should_tile = vae_tiled_encode or auto_vae_tiled_encode or force_low_memory_tiling
 
     if should_tile:
         encoder = nodes.VAEEncodeTiled()

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -563,6 +563,8 @@ def _gaussian_kernel(kernel_size, sigma):
 def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
     """Return NHWC torch.Tensor from ndim == 2/3/4 mask data.
 
+    ``kernel_size`` is the caller-facing feather radius kept for compatibility
+    with existing nodes and is converted to the odd full kernel size internally.
     Blur on the mask's current device. The old code called
     ``mask.to(comfy.model_management.get_torch_device())`` without using the
     returned tensor, which could still create a transient CUDA copy before the
@@ -581,14 +583,15 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
     if kernel_size <= 0:
         return mask
 
-    kernel_size = kernel_size * 2 + 1
+    feather_radius = kernel_size
+    full_kernel_size = feather_radius * 2 + 1
 
     shortest = min(mask.shape[1], mask.shape[2])
-    if shortest <= kernel_size:
-        kernel_size = int(shortest / 2)
-        if kernel_size % 2 == 0:
-            kernel_size += 1
-        if kernel_size < 3:
+    if shortest <= full_kernel_size:
+        full_kernel_size = int(shortest / 2)
+        if full_kernel_size % 2 == 0:
+            full_kernel_size += 1
+        if full_kernel_size < 3:
             return mask  # skip feathering
 
     prev_device = mask.device
@@ -599,7 +602,7 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
 
     logging.info(
         "[Impact Pack] tensor_gaussian_blur_mask[%s] start "
-        f"shape={tuple(mask.shape)} kernel={kernel_size} sigma={sigma} "
+        f"shape={tuple(mask.shape)} feather_radius={feather_radius} kernel={full_kernel_size} sigma={sigma} "
         f"device={prev_device} work_device={work_device}",
         blur_trace
     )
@@ -610,7 +613,7 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
     # previous unassigned .to(...) calls. Keep the output shape NHWC.
     mask_nchw = mask_work[:, None, ..., 0]
     try:
-        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=kernel_size, sigma=sigma)(mask_nchw)
+        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=full_kernel_size, sigma=sigma)(mask_nchw)
     except Exception:
         if mask_nchw.device.type == "cpu":
             raise
@@ -618,7 +621,7 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
             "[Impact Pack] tensor_gaussian_blur_mask[%s] failed on device=%s; retrying on cpu",
             blur_trace, mask_nchw.device, exc_info=True
         )
-        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=kernel_size, sigma=sigma)(mask_nchw.cpu())
+        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=full_kernel_size, sigma=sigma)(mask_nchw.cpu())
     blurred_mask = blurred_mask[:, 0, ..., None]
 
     if blurred_mask.device != prev_device or blurred_mask.dtype != prev_dtype:

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -128,6 +128,15 @@ def general_tensor_resize(image, w: int, h: int):
 LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
 def tensor_resize(image, w: int, h: int):
     _tensor_check_image(image)
+    w = int(w)
+    h = int(h)
+    if w <= 0 or h <= 0:
+        raise ValueError(f"Invalid resize target: {(w, h)}")
+
+    cur_w, cur_h = tensor_get_size(image)
+    if cur_w == w and cur_h == h:
+        return image
+
     if image.shape[3] >= 3:
         scaled_images = TensorBatchBuilder()
         for single_image in image:

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -390,12 +390,12 @@ def tensor_paste(image1, image2, left_top, mask):
             image1[:, dst_y0:dst_y1, x:x+w, :] = (1 - mask_chunk) * region1 + mask_chunk * region2
 
         elif c1 == 4 and c2 == 4:
-            image1[:, dst_y0:dst_y1, x:x+w, :3] = (
-                (1 - mask_chunk) * region1[:, :, :, :3] +
-                mask_chunk * region2[:, :, :, :3]
-            )
             a1 = region1[:, :, :, 3:4]
             a2 = region2[:, :, :, 3:4] * mask_chunk
+            image1[:, dst_y0:dst_y1, x:x+w, :3] = (
+                (1 - a2) * region1[:, :, :, :3] +
+                a2 * region2[:, :, :, :3]
+            )
             image1[:, dst_y0:dst_y1, x:x+w, 3:4] = a1 + a2 * (1 - a1)
 
         elif c1 == 4 and c2 == 3:

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -166,17 +166,7 @@ def adjust_bbox_after_resize(bbox, original_size, target_size, padding):
     return x1, y1, x2, y2
 
 
-def general_tensor_resize(image, w: int, h: int):
-    _tensor_check_image(image)
-    image = image.permute(0, 3, 1, 2)
-    image = torch.nn.functional.interpolate(image, size=(h, w), mode="bilinear")
-    image = image.permute(0, 2, 3, 1)
-    return image
-
-
-# TODO: Sadly, we need LANCZOS
-LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
-def tensor_resize(image, w: int, h: int):
+def general_tensor_resize(image, w: int, h: int, mode="bilinear"):
     _tensor_check_image(image)
     w = int(w)
     h = int(h)
@@ -187,19 +177,38 @@ def tensor_resize(image, w: int, h: int):
     if cur_w == w and cur_h == h:
         return image
 
-    if image.shape[3] >= 3:
-        scaled_images = TensorBatchBuilder()
-        for single_image in image:
-            single_image = single_image.unsqueeze(0)
-            single_pil = tensor2pil(single_image)
-            scaled_pil = single_pil.resize((w, h), resample=LANCZOS)
+    original_device = image.device
+    original_dtype = image.dtype
 
-            single_image = pil2tensor(scaled_pil)
-            scaled_images.concat(single_image)
+    # Resize directly with torch instead of round-tripping through PIL.
+    #
+    # PIL.Image.resize can terminate the interpreter with SIGFPE/SIGSEGV in native
+    # code for some resize inputs. That cannot be recovered with try/except, so the
+    # detailer path must avoid PIL for tensor resizing entirely.
+    nchw = image.movedim(-1, 1).contiguous().to(dtype=torch.float32)
 
-        return scaled_images.tensor
+    if mode in ("bilinear", "bicubic"):
+        resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode, align_corners=False)
+    elif mode in ("nearest", "area"):
+        resized = torch.nn.functional.interpolate(nchw, size=(h, w), mode=mode)
     else:
-        return general_tensor_resize(image, w, h)
+        raise ValueError(f"Unsupported resize mode: {mode}")
+
+    resized = resized.movedim(1, -1).contiguous()
+
+    if image.shape[-1] >= 3:
+        resized = resized.clamp(0.0, 1.0)
+
+    return resized.to(device=original_device, dtype=original_dtype)
+
+
+# Kept for compatibility with callers/imports, but tensor_resize no longer uses
+# PIL because a native PIL resize crash cannot be handled safely from Python.
+LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
+def tensor_resize(image, w: int, h: int):
+    _tensor_check_image(image)
+    mode = "bicubic" if image.shape[3] >= 3 else "bilinear"
+    return general_tensor_resize(image, w, h, mode=mode)
 
 
 def tensor_get_size(image):

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -648,7 +648,7 @@ def crop_image(image, crop_region):
     return crop_tensor4(image, crop_region)
 
 
-def to_latent_image(pixels, vae, vae_tiled_encode=False):
+def to_latent_image(pixels, vae, vae_tiled_encode=False, auto_vae_tiled_encode=False):
     x = pixels.shape[1]
     y = pixels.shape[2]
     if pixels.shape[1] != x or pixels.shape[2] != y:
@@ -656,9 +656,9 @@ def to_latent_image(pixels, vae, vae_tiled_encode=False):
 
     start = time.time()
     tile_size, overlap = get_vae_tiled_encode_settings(pixels)
-    force_low_memory_tiling = tile_size < 512
+    should_tile = vae_tiled_encode or auto_vae_tiled_encode
 
-    if vae_tiled_encode or force_low_memory_tiling:
+    if should_tile:
         encoder = nodes.VAEEncodeTiled()
         try:
             supports_overlap = 'overlap' in inspect.signature(encoder.encode).parameters
@@ -683,8 +683,8 @@ def get_vae_tiled_encode_settings(pixels):
     w = int(pixels.shape[2])
     megapixels = (h * w) / 1_000_000.0
 
-    # FaceDetailer crops at/above ~1.5MP have shown sustained VAE encode pressure
-    # with 512px tiles; step down further past ~3MP to protect VRAM headroom.
+    # FaceDetailer encode should stay on the tiled path once selected; the tile
+    # geometry adapts by crop size, but 512/64 is still the tiled path.
     if megapixels >= 3.0:
         tile_size = 128
     elif megapixels >= 1.5:

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -9,6 +9,7 @@ from PIL import Image
 import comfy
 import time
 import logging
+import inspect
 
 
 class TensorBatchBuilder:
@@ -658,7 +659,17 @@ def to_latent_image(pixels, vae, vae_tiled_encode=False):
     force_low_memory_tiling = tile_size < 512
 
     if vae_tiled_encode or force_low_memory_tiling:
-        encoded = nodes.VAEEncodeTiled().encode(vae, pixels, tile_size, overlap=overlap)[0]
+        encoder = nodes.VAEEncodeTiled()
+        try:
+            supports_overlap = 'overlap' in inspect.signature(encoder.encode).parameters
+        except (TypeError, ValueError):
+            supports_overlap = False
+
+        if supports_overlap:
+            encoded = encoder.encode(vae, pixels, tile_size, overlap=overlap)[0]
+        else:
+            logging.warning("[Impact Pack] Your ComfyUI is outdated.")
+            encoded = encoder.encode(vae, pixels, tile_size)[0]
         logging.info(f"[Impact Pack] vae encoded (tiled {tile_size}/{overlap}) in {time.time() - start:.1f}s")
     else:
         encoded = nodes.VAEEncode().encode(vae, pixels)[0]

--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import torchvision
 import cv2
@@ -614,15 +615,49 @@ def _gaussian_kernel(kernel_size, sigma):
     return kernel / kernel.sum()
 
 
+def _impact_is_wsl():
+    try:
+        release = os.uname().release.lower()
+        return "microsoft" in release or "wsl" in release
+    except (AttributeError, OSError):
+        return False
+
+
+def _impact_env_enabled(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _impact_cv2_gaussian_blur_mask_cpu(mask, kernel_size, sigma):
+    """Blur an NHWC mask on CPU without torch/torchvision convolution."""
+    prev_dtype = mask.dtype
+    arr = mask.detach().cpu().to(dtype=torch.float32).numpy()
+    if arr.ndim != 4 or arr.shape[-1] != 1:
+        raise ValueError(f"Expected NHWC single-channel mask, got {arr.shape}")
+
+    out = np.empty_like(arr, dtype=np.float32)
+    for i in range(arr.shape[0]):
+        plane = np.ascontiguousarray(arr[i, :, :, 0])
+        out[i, :, :, 0] = cv2.GaussianBlur(
+            plane,
+            (int(kernel_size), int(kernel_size)),
+            float(sigma),
+            borderType=cv2.BORDER_REFLECT_101,
+        )
+
+    return torch.from_numpy(out).to(dtype=prev_dtype)
+
+
 def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
     """Return NHWC torch.Tensor from ndim == 2/3/4 mask data.
 
     ``kernel_size`` is the caller-facing feather radius kept for compatibility
     with existing nodes and is converted to the odd full kernel size internally.
-    Blur on the mask's current device. The old code called
-    ``mask.to(comfy.model_management.get_torch_device())`` without using the
-    returned tensor, which could still create a transient CUDA copy before the
-    detailer reached its first resize/model-load log.
+    On WSL, CPU mask feathering deliberately uses OpenCV instead of torchvision
+    GaussianBlur. The torchvision CPU path can wedge inside PyTorch native CPU
+    convolution/threadpool after repeated CUDA-heavy FaceDetailer passes.
     """
     if isinstance(mask, np.ndarray):
         mask = torch.from_numpy(mask)
@@ -651,6 +686,9 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
     prev_device = mask.device
     prev_dtype = mask.dtype
     work_device = prev_device
+    if _impact_is_wsl():
+        work_device = torch.device("cpu")
+
     blur_trace = format(id(mask) & 0xfffffff, "x")
     blur_start = time.perf_counter()
 
@@ -661,22 +699,30 @@ def tensor_gaussian_blur_mask(mask, kernel_size, sigma=10.0):
         blur_trace
     )
 
-    mask_work = mask.to(device=work_device, dtype=torch.float32, copy=False)
+    use_cv2_cpu = (
+        work_device.type == "cpu"
+        and _impact_is_wsl()
+        and not _impact_env_enabled("IMPACT_WSL_USE_TORCHVISION_MASK_BLUR", False)
+    )
+    if use_cv2_cpu:
+        blurred_mask = _impact_cv2_gaussian_blur_mask_cpu(mask, full_kernel_size, sigma)
+    else:
+        mask_work = mask.to(device=work_device, dtype=torch.float32, copy=False)
 
-    # torchvision GaussianBlur handles NCHW tensors and avoids the broken
-    # previous unassigned .to(...) calls. Keep the output shape NHWC.
-    mask_nchw = mask_work[:, None, ..., 0]
-    try:
-        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=full_kernel_size, sigma=sigma)(mask_nchw)
-    except Exception:
-        if mask_nchw.device.type == "cpu":
-            raise
-        logging.warning(
-            "[Impact Pack] tensor_gaussian_blur_mask[%s] failed on device=%s; retrying on cpu",
-            blur_trace, mask_nchw.device, exc_info=True
-        )
-        blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=full_kernel_size, sigma=sigma)(mask_nchw.cpu())
-    blurred_mask = blurred_mask[:, 0, ..., None]
+        # torchvision GaussianBlur handles NCHW tensors and avoids the broken
+        # previous unassigned .to(...) calls. Keep the output shape NHWC.
+        mask_nchw = mask_work[:, None, ..., 0]
+        try:
+            blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=full_kernel_size, sigma=sigma)(mask_nchw)
+        except Exception:
+            if mask_nchw.device.type == "cpu":
+                raise
+            logging.warning(
+                "[Impact Pack] tensor_gaussian_blur_mask[%s] failed on device=%s; retrying on cpu",
+                blur_trace, mask_nchw.device, exc_info=True
+            )
+            blurred_mask = torchvision.transforms.GaussianBlur(kernel_size=full_kernel_size, sigma=sigma)(mask_nchw.cpu())
+        blurred_mask = blurred_mask[:, 0, ..., None]
 
     if blurred_mask.device != prev_device or blurred_mask.dtype != prev_dtype:
         blurred_mask = blurred_mask.to(device=prev_device, dtype=prev_dtype, copy=False)


### PR DESCRIPTION
## Summary

This PR now has two main parts:

1. expand FaceDetailer’s VAE tiling support so the tiled path is respected consistently, can auto-adapt by crop size, and exposes explicit tile controls
2. add an optional `post_detail_shrink` correction for the higher-resolution patch-size drift I observed with FLUX.2 Klein 9B

There is also a small hardening fix for Impact Pack’s existing final resize path after detail decode.

## FaceDetailer tiled VAE changes

This branch broadens FaceDetailer’s tiled VAE support in a few ways.

### A. FaceDetailer now respects tiled VAE encode more consistently

The branch fixes the path where FaceDetailer/inpaint conditioning could still bypass the intended tiled VAE encode behavior.

To do that, it introduces a small proxy VAE wrapper for the inpaint-conditioning path so encode requests still go through tiled encode with the resolved tile settings when that path is selected.

### B. Adaptive tiled encode can now stay on the tiled path

The branch adds adaptive tile-size resolution based on crop resolution:

- `>= 3.0 MP` -> `128` tiles
- `>= 1.5 MP` -> `256` tiles
- otherwise -> `512` tiles

with overlap defaulting to `max(16, tile_size // 8)` unless the user supplies an explicit overlap.

This matters because the problem I was hitting was not just “use tiled VAE once”. FaceDetailer needed to stay on the tiled encode path consistently, including the `512/64` case, instead of dropping back to the plain VAE path for those smaller adaptive tile sizes.

### C. FaceDetailer nodes now expose explicit VAE tile controls

The relevant FaceDetailer nodes now expose:

- `force_adaptive_tiled_encode`
- `tile_size`
- `tile_overlap`

These are threaded through the FaceDetailer / FaceDetailerPipe path into encode/decode.

In addition, the existing tiled decode path now uses the resolved tile size / overlap instead of always hardcoding the old default decode settings, while still guarding the `overlap` kwarg for older ComfyUI versions.

## Optional post_detail_shrink

This PR also keeps the original opt-in `post_detail_shrink` feature.

I added it to compensate for a behavior I observed with FLUX.2 Klein 9B: when FaceDetailer regenerates crops above roughly ~1 MP, the returned patch can come back slightly and fairly uniformly enlarged relative to the original surrounding image.

Because FaceDetailer only regenerates the cropped face region and then composites that result back into the untouched source image, that size drift becomes visible at the seam.

This feature does not try to solve the root cause inside FLUX.2 Klein 9B. It adds a practical, opt-in correction on the Impact Pack side that shrinks the regenerated patch slightly before compositing it back.

Added controls:

- `post_detail_shrink` (`BOOLEAN`, default: `False`)
- `post_detail_shrink_scale` (`FLOAT`, default: `0.995`, step: `0.001`)

When enabled:

- the regenerated patch is resized down slightly after the detail pass
- the resized patch is anchored around the detected bbox center
- the paste mask is shifted/scaled together with the regenerated patch
- the cropped seg mask is shifted/scaled as well so downstream mask and SEGS consumers stay aligned

This uses the new helper:

- `utils.shift_within_canvas(...)`

## Mask output fix

`FaceDetailer.enhance_face()` now builds its output mask from the updated returned segs after detailing instead of always rebuilding it from the original input segs.

Without that change, enabling `post_detail_shrink` could leave the public `mask` output larger than the actually corrected region.

## Resize-path hardening

Independently of the tiling and shrink changes, I also hit a crash in Impact Pack’s existing final resize path after detail decoding while running a FLUX.2 FaceDetailer workflow.

The crash stack ended in:

- `PIL.Image.resize`
- `modules/impact/utils.py:tensor_resize`
- `modules/impact/core.py:enhance_detail`

To harden that path, this branch also makes two small changes:

- `modules/impact/core.py:enhance_detail()` now only calls `utils.tensor_resize(...)` when the decoded image size actually differs from the requested `(w, h)`
- `modules/impact/utils.py:tensor_resize(...)` now normalizes `w` / `h` to plain integers, rejects non-positive targets, and returns early for same-size requests instead of entering Pillow unnecessarily

## Scope / compatibility notes

The `post_detail_shrink` feature remains intentionally scoped around the FLUX.2 Klein 9B behavior I observed. It is disabled by default.

The tiled VAE work is broader in applicability than `post_detail_shrink`, because it improves how FaceDetailer handles larger crops and how it preserves the intended tiled encode/decode path.

One important compatibility note: this branch intentionally changes the default FaceDetailer encode behavior by adding `force_adaptive_tiled_encode = True` on the FaceDetailer node path. That means FaceDetailer will prefer the adaptive tiled encode path by default. Users who want the older fallback behavior can disable `force_adaptive_tiled_encode`.

So this PR is not purely a no-behavior-change refactor. The shrink feature is opt-in, but the FaceDetailer tiled-encode behavior is intentionally strengthened by default.

## Practical effect

For users, the main outcomes are:

- FaceDetailer is less likely to fall back to the plain VAE encode path when the intent is to stay tiled
- FaceDetailer now exposes tile-size / overlap controls directly
- tiled decode uses the same resolved tile geometry instead of fixed defaults
- FLUX.2 users get an optional seam-reduction correction via `post_detail_shrink`
- the existing resize path is harder to crash on invalid or no-op resize requests