### PR TITLE
fix: Change default wildcard loading encoding to UTF-8 to fix garbled text

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -42,21 +42,21 @@ class LazyWildcardLoader:
     def _load_txt(self):
         """Load .txt wildcard file"""
         try:
-            with open(self.file_path, 'r', encoding="ISO-8859-1") as f:
+            with open(self.file_path, 'r', encoding="UTF-8") as f:
                 lines = f.read().splitlines()
                 return [x for x in lines if x.strip() and not x.strip().startswith('#')]
         except (yaml.reader.ReaderError, UnicodeDecodeError):
-            with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+            with open(self.file_path, 'r', encoding="ISO-8859-1", errors="ignore") as f:
                 lines = f.read().splitlines()
                 return [x for x in lines if x.strip() and not x.strip().startswith('#')]
 
     def _load_yaml(self):
         """Load .yaml/.yml wildcard file"""
         try:
-            with open(self.file_path, 'r', encoding="ISO-8859-1") as f:
+            with open(self.file_path, 'r', encoding="UTF-8") as f:
                 return yaml.load(f, Loader=yaml.FullLoader)
         except (yaml.reader.ReaderError, UnicodeDecodeError):
-            with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+            with open(self.file_path, 'r', encoding="ISO-8859-1", errors="ignore") as f:
                 return yaml.load(f, Loader=yaml.FullLoader)
 
     def get_data(self):
@@ -360,11 +360,11 @@ def get_wildcard_value(key):
 def load_txt_wildcard(file_path):
     """Load a .txt wildcard file"""
     try:
-        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+        with open(file_path, 'r', encoding="UTF-8") as f:
             lines = f.read().splitlines()
             return [x for x in lines if x.strip() and not x.strip().startswith('#')]
     except (yaml.reader.ReaderError, UnicodeDecodeError):
-        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+        with open(file_path, 'r', encoding="ISO-8859-1", errors="ignore") as f:
             lines = f.read().splitlines()
             return [x for x in lines if x.strip() and not x.strip().startswith('#')]
 
@@ -374,10 +374,10 @@ def load_yaml_wildcard(file_path, key_prefix=''):
     global loaded_wildcards
 
     try:
-        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+        with open(file_path, 'r', encoding="UTF-8") as f:
             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
     except (yaml.reader.ReaderError, UnicodeDecodeError):
-        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+        with open(file_path, 'r', encoding="ISO-8859-1", errors="ignore") as f:
             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
 
     if not yaml_data:
@@ -480,11 +480,11 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                 else:
                     # Load data immediately (original behavior)
                     try:
-                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                        with open(file_path, 'r', encoding="UTF-8") as f:
                             lines = f.read().splitlines()
                             wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
                     except yaml.reader.ReaderError:
-                        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                        with open(file_path, 'r', encoding="ISO-8859-1", errors="ignore") as f:
                             lines = f.read().splitlines()
                             wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
             elif file.endswith('.yaml') or file.endswith('.yml'):
@@ -501,10 +501,10 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                 else:
                     # Load data immediately (original behavior)
                     try:
-                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                        with open(file_path, 'r', encoding="UTF-8") as f:
                             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
                     except yaml.reader.ReaderError:
-                        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                        with open(file_path, 'r', encoding="ISO-8859-1", errors="ignore") as f:
                             yaml_data = yaml.load(f, Loader=yaml.FullLoader)
 
                     for k, v in yaml_data.items():


### PR DESCRIPTION
Fixes #1196 

The current wildcard files try to read using `ISO-8859-1` first, and it never triggers a `UnicodeDecodeError` for UTF-8 files, so the the `utf-8` fallback block is just completely dead code. This causes non-English characters to load as garbled text. This PR simply inverts the logic by trying `utf-8` first, and falls back to `ISO-8859-1` if a decode error occurs. (I kept the yaml error catch as it was).

Tested locally and it works fine.