### PR TITLE
Fix deprecated legacy API imports with modern API shims

### DIFF
--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -1,7 +1,13 @@
 import { ComfyApp, app } from "../../scripts/app.js";
-import { ComfyDialog, $el } from "../../scripts/ui.js";
 import { api } from "../../scripts/api.js";
 import { customAlert, isBeforeFrontendVersion } from "./common.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let ComfyDialog, $el;
+if (window?.comfyAPI?.ui) {
+    ({ ComfyDialog, $el } = window.comfyAPI.ui);
+} else {
+    ({ ComfyDialog, $el } = await import("../../scripts/ui.js"));
+}
 
 const is_legacy_front = () => isBeforeFrontendVersion('1.16.9');
 

--- a/js/impact-sam-editor.js
+++ b/js/impact-sam-editor.js
@@ -1,8 +1,21 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
-import { ComfyDialog, $el } from "../../scripts/ui.js";
-import { ComfyApp } from "../../scripts/app.js";
-import { ClipspaceDialog } from "../../extensions/core/clipspace.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js + clipspace.js warnings) ===
+let ComfyDialog, $el, ComfyApp, ClipspaceDialog;
+
+if (window?.comfyAPI?.ui) {
+    ({ ComfyDialog, $el } = window.comfyAPI.ui);
+    ComfyApp = window.comfyAPI.app?.ComfyApp || window.ComfyApp;
+} else {
+    ({ ComfyDialog, $el } = await import("../../scripts/ui.js"));
+    ComfyApp = (await import("../../scripts/app.js")).ComfyApp;
+}
+
+if (window?.comfyAPI?.clipspace?.ClipspaceDialog) {
+    ({ ClipspaceDialog } = window.comfyAPI.clipspace);
+} else {
+    ({ ClipspaceDialog } = await import("../../extensions/core/clipspace.js"));
+}
 
 function addMenuHandler(nodeType, cb) {
 	const getOpts = nodeType.prototype.getExtraMenuOptions;

--- a/js/impact-segs-picker.js
+++ b/js/impact-segs-picker.js
@@ -1,6 +1,12 @@
 import { ComfyApp, app } from "../../scripts/app.js";
-import { ComfyDialog, $el } from "../../scripts/ui.js";
 import { api } from "../../scripts/api.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let ComfyDialog, $el;
+if (window?.comfyAPI?.ui) {
+    ({ ComfyDialog, $el } = window.comfyAPI.ui);
+} else {
+    ({ ComfyDialog, $el } = await import("../../scripts/ui.js"));
+}
 
 async function open_picker(node) {
     const resp = await api.fetchApi(`/impact/segs/picker/count?id=${node.id}`);


### PR DESCRIPTION
ComfyUI has deprecated direct imports of /scripts/ui.js, 
/extensions/core/clipspace.js and now logs DEPRECATION WARNING 
in the browser console when these paths are imported directly.

This replaces the static imports in 3 files with shims that check 
for the new window.comfyAPI API first, falling back to the legacy 
path for backward compatibility:

- impact-pack.js: ui.js shim
- impact-sam-editor.js: ui.js + clipspace.js shims
- impact-segs-picker.js: ui.js shim