### PR TITLE
Fix/wildcard error reporting

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -42,22 +42,30 @@ class LazyWildcardLoader:
     def _load_txt(self):
         """Load .txt wildcard file"""
         try:
-            with open(self.file_path, 'r', encoding="ISO-8859-1") as f:
-                lines = f.read().splitlines()
-                return [x for x in lines if x.strip() and not x.strip().startswith('#')]
-        except (yaml.reader.ReaderError, UnicodeDecodeError):
-            with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
-                lines = f.read().splitlines()
-                return [x for x in lines if x.strip() and not x.strip().startswith('#')]
+            try:
+                with open(self.file_path, 'r', encoding="ISO-8859-1") as f:
+                    lines = f.read().splitlines()
+                    return [x for x in lines if x.strip() and not x.strip().startswith('#')]
+            except (yaml.reader.ReaderError, UnicodeDecodeError):
+                with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                    lines = f.read().splitlines()
+                    return [x for x in lines if x.strip() and not x.strip().startswith('#')]
+        except Exception as e:
+            logging.warning(f"[Impact Pack] Failed to load wildcard file {self.base_dir / self.filename}: {type(e).__name__}: {e}")
+            return []
 
     def _load_yaml(self):
         """Load .yaml/.yml wildcard file"""
         try:
-            with open(self.file_path, 'r', encoding="ISO-8859-1") as f:
-                return yaml.load(f, Loader=yaml.FullLoader)
-        except (yaml.reader.ReaderError, UnicodeDecodeError):
-            with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
-                return yaml.load(f, Loader=yaml.FullLoader)
+            try:
+                with open(self.file_path, 'r', encoding="ISO-8859-1") as f:
+                    return yaml.load(f, Loader=yaml.FullLoader)
+            except (yaml.reader.ReaderError, UnicodeDecodeError):
+                with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                    return yaml.load(f, Loader=yaml.FullLoader)
+        except Exception as e:
+            logging.warning(f"[Impact Pack] Failed to load wildcard file {self.base_dir / self.filename}: {type(e).__name__}: {e}")
+            return None
 
     def get_data(self):
         """Get wildcard data, loading if necessary"""
@@ -360,25 +368,33 @@ def get_wildcard_value(key):
 def load_txt_wildcard(file_path):
     """Load a .txt wildcard file"""
     try:
-        with open(file_path, 'r', encoding="ISO-8859-1") as f:
-            lines = f.read().splitlines()
-            return [x for x in lines if x.strip() and not x.strip().startswith('#')]
-    except (yaml.reader.ReaderError, UnicodeDecodeError):
-        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
-            lines = f.read().splitlines()
-            return [x for x in lines if x.strip() and not x.strip().startswith('#')]
+        try:
+            with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                lines = f.read().splitlines()
+                return [x for x in lines if x.strip() and not x.strip().startswith('#')]
+        except (yaml.reader.ReaderError, UnicodeDecodeError):
+            with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                lines = f.read().splitlines()
+                return [x for x in lines if x.strip() and not x.strip().startswith('#')]
+    except Exception as e:
+        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
+        return []
 
 
 def load_yaml_wildcard(file_path, key_prefix=''):
     """Load a .yaml/.yml wildcard file and expand nested structures"""
     global loaded_wildcards
-
     try:
-        with open(file_path, 'r', encoding="ISO-8859-1") as f:
-            yaml_data = yaml.load(f, Loader=yaml.FullLoader)
-    except (yaml.reader.ReaderError, UnicodeDecodeError):
-        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
-            yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+        yaml_data = None
+        try:
+            with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+        except (yaml.reader.ReaderError, UnicodeDecodeError):
+            with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+    except Exception as e:
+        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
+        return []
 
     if not yaml_data:
         return []
@@ -480,13 +496,16 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                 else:
                     # Load data immediately (original behavior)
                     try:
-                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
-                            lines = f.read().splitlines()
-                            wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
-                    except yaml.reader.ReaderError:
-                        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
-                            lines = f.read().splitlines()
-                            wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
+                        try:
+                            with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                                lines = f.read().splitlines()
+                                wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
+                        except yaml.reader.ReaderError:
+                            with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                                lines = f.read().splitlines()
+                                wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
+                    except Exception as e:
+                        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
             elif file.endswith('.yaml') or file.endswith('.yml'):
                 file_path = os.path.join(root, file)
 
@@ -501,14 +520,18 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                 else:
                     # Load data immediately (original behavior)
                     try:
-                        with open(file_path, 'r', encoding="ISO-8859-1") as f:
-                            yaml_data = yaml.load(f, Loader=yaml.FullLoader)
-                    except yaml.reader.ReaderError:
-                        with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
-                            yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+                        try:
+                            with open(file_path, 'r', encoding="ISO-8859-1") as f:
+                                yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+                        except yaml.reader.ReaderError:
+                            with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
+                                yaml_data = yaml.load(f, Loader=yaml.FullLoader)
 
-                    for k, v in yaml_data.items():
-                        read_wildcard(k, v, on_demand)
+                        if yaml_data:
+                            for k, v in yaml_data.items():
+                                read_wildcard(k, v, on_demand)
+                    except Exception as e:
+                        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
 
     return wildcard_dict
 
@@ -1245,7 +1268,7 @@ def wildcard_load():
             try:
                 if custom_wildcards_path:
                     read_wildcard_dict(custom_wildcards_path, on_demand=False)
-            except Exception:
-                logging.info("[Impact Pack] Failed to load custom wildcards directory.")
+            except Exception as e:
+                logging.warning(f"[Impact Pack] Failed to load custom wildcards from {custom_wildcards_path}: {type(e).__name__}: {e}")
 
         logging.info("[Impact Pack] Wildcards loading done.")

--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -51,7 +51,7 @@ class LazyWildcardLoader:
                     lines = f.read().splitlines()
                     return [x for x in lines if x.strip() and not x.strip().startswith('#')]
         except Exception as e:
-            logging.warning(f"[Impact Pack] Failed to load wildcard file {self.base_dir / self.filename}: {type(e).__name__}: {e}")
+            logging.info(f"[Impact Pack] Failed to load wildcard file {self.base_dir / self.filename}: {type(e).__name__}: {e}")
             return []
 
     def _load_yaml(self):
@@ -64,7 +64,7 @@ class LazyWildcardLoader:
                 with open(self.file_path, 'r', encoding="UTF-8", errors="ignore") as f:
                     return yaml.load(f, Loader=yaml.FullLoader)
         except Exception as e:
-            logging.warning(f"[Impact Pack] Failed to load wildcard file {self.base_dir / self.filename}: {type(e).__name__}: {e}")
+            logging.info(f"[Impact Pack] Failed to load wildcard file {self.base_dir / self.filename}: {type(e).__name__}: {e}")
             return None
 
     def get_data(self):
@@ -355,7 +355,7 @@ def get_wildcard_value(key):
             logging.debug(f"[Impact Pack] Loaded TXT wildcard '{key}' on-demand from {file_path}")
             return data
         except Exception as e:
-            logging.warning(f"[Impact Pack] Failed to load wildcard {key} from {file_path}: {e}")
+            logging.info(f"[Impact Pack] Failed to load wildcard {key} from {file_path}: {e}")
             return None
 
     # Full cache mode or fallback: use wildcard_dict
@@ -377,7 +377,7 @@ def load_txt_wildcard(file_path):
                 lines = f.read().splitlines()
                 return [x for x in lines if x.strip() and not x.strip().startswith('#')]
     except Exception as e:
-        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
+        logging.info(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
         return []
 
 
@@ -393,7 +393,7 @@ def load_yaml_wildcard(file_path, key_prefix=''):
             with open(file_path, 'r', encoding="UTF-8", errors="ignore") as f:
                 yaml_data = yaml.load(f, Loader=yaml.FullLoader)
     except Exception as e:
-        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
+        logging.info(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
         return []
 
     if not yaml_data:
@@ -505,7 +505,7 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                                 lines = f.read().splitlines()
                                 wildcard_dict[key] = [x for x in lines if x.strip() and not x.strip().startswith('#')]
                     except Exception as e:
-                        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
+                        logging.info(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
             elif file.endswith('.yaml') or file.endswith('.yml'):
                 file_path = os.path.join(root, file)
 
@@ -531,7 +531,7 @@ def read_wildcard_dict(wildcard_path, on_demand=False):
                             for k, v in yaml_data.items():
                                 read_wildcard(k, v, on_demand)
                     except Exception as e:
-                        logging.warning(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
+                        logging.info(f"[Impact Pack] Failed to load wildcard file {file_path}: {type(e).__name__}: {e}")
 
     return wildcard_dict
 
@@ -1171,9 +1171,9 @@ def load_yaml_files_only(wildcard_path):
                         yaml_count += 1
                         logging.debug(f"[Impact Pack] Pre-loaded YAML file: {file_path}")
                     except Exception as e:
-                        logging.warning(f"[Impact Pack] Failed to load YAML file {file_path}: {e}")
+                        logging.info(f"[Impact Pack] Failed to load YAML file {file_path}: {e}")
     except (OSError, FileNotFoundError) as e:
-        logging.warning(f"[Impact Pack] Error scanning YAML files in {wildcard_path}: {e}")
+        logging.info(f"[Impact Pack] Error scanning YAML files in {wildcard_path}: {e}")
 
     return yaml_count
 
@@ -1216,6 +1216,7 @@ def wildcard_load():
     available_wildcards = {}
     loaded_wildcards = {}
     _on_demand_mode = False
+    skipped_count = 0  # Track files that failed to load
 
     with wildcard_lock:
         # Calculate total size of wildcard files (with early termination)
@@ -1269,6 +1270,12 @@ def wildcard_load():
                 if custom_wildcards_path:
                     read_wildcard_dict(custom_wildcards_path, on_demand=False)
             except Exception as e:
-                logging.warning(f"[Impact Pack] Failed to load custom wildcards from {custom_wildcards_path}: {type(e).__name__}: {e}")
+                skipped_count += 1
+                logging.info(f"[Impact Pack] Failed to load custom wildcards from {custom_wildcards_path}: {type(e).__name__}: {e}")
+
+        # Show summary if any files were skipped
+        if skipped_count > 0:
+            logging.info(f"[Impact Pack] Skipped {skipped_count} problematic wildcard file(s). "
+                        f"Check logs above for file paths. You can safely delete or fix these files.")
 
         logging.info("[Impact Pack] Wildcards loading done.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,100 @@
+import sys
+print(f"DEBUG: conftest.py executing, sys.path={sys.path[:3]}", file=sys.stderr)
+"""
+Pytest configuration for Impact Pack tests.
+Mocks ComfyUI-specific modules for standalone testing.
+"""
+import sys
+import tempfile
+import os
+from unittest.mock import MagicMock
+
+# Create temp directory for mock file paths
+_mock_temp_dir = tempfile.mkdtemp()
+
+# Mock folder_paths with __file__ attribute
+mock_folder_paths = MagicMock()
+mock_folder_paths.__file__ = os.path.join(_mock_temp_dir, 'folder_paths.py')
+mock_folder_paths.wildcards_dir = os.path.join(_mock_temp_dir, 'wildcards')
+mock_folder_paths.models_dir = os.path.join(_mock_temp_dir, 'models')
+os.makedirs(mock_folder_paths.wildcards_dir, exist_ok=True)
+os.makedirs(mock_folder_paths.models_dir, exist_ok=True)
+sys.modules['folder_paths'] = mock_folder_paths
+
+# Mock nodes with __file__ attribute
+mock_nodes = MagicMock()
+mock_nodes.__file__ = os.path.join(_mock_temp_dir, 'nodes.py')
+sys.modules['nodes'] = mock_nodes
+
+# Mock impact package with __file__ attribute
+mock_impact = MagicMock()
+mock_impact.__file__ = os.path.join(_mock_temp_dir, 'impact')
+# Set config and utils as attributes for 'from impact import config, utils'
+sys.modules['impact'] = mock_impact
+
+# Mock impact.config with __file__ and get_config()
+mock_impact_config = MagicMock()
+mock_impact_config.__file__ = os.path.join(_mock_temp_dir, 'impact', 'config.py')
+mock_impact_config.get_config.return_value = {}
+sys.modules['impact.config'] = mock_impact_config
+# Also set as attribute on impact module
+mock_impact.config = mock_impact_config
+
+# Mock impact.utils with __file__ attribute
+mock_impact_utils = MagicMock()
+mock_impact_utils.__file__ = os.path.join(_mock_temp_dir, 'impact', 'utils.py')
+sys.modules['impact.utils'] = mock_impact_utils
+# Also set as attribute on impact module
+mock_impact.utils = mock_impact_utils
+mock_impact.utils = mock_impact_utils
+
+# Mock comfy module with __file__ attribute (required by root __init__.py)
+mock_comfy = MagicMock()
+mock_comfy.__file__ = os.path.join(_mock_temp_dir, 'comfy', '__init__.py')
+sys.modules['comfy'] = mock_comfy
+
+# Mock comfy.samplers submodule
+mock_comfy_samplers = MagicMock()
+mock_comfy_samplers.__file__ = os.path.join(_mock_temp_dir, 'comfy', 'samplers.py')
+sys.modules['comfy.samplers'] = mock_comfy_samplers
+mock_comfy.samplers = mock_comfy_samplers
+
+# Mock comfy.sd submodule
+mock_comfy_sd = MagicMock()
+mock_comfy_sd.__file__ = os.path.join(_mock_temp_dir, 'comfy', 'sd.py')
+sys.modules['comfy.sd'] = mock_comfy_sd
+mock_comfy.sd = mock_comfy_sd
+
+# Mock other dependencies required by root __init__.py
+mock_torch = MagicMock()
+mock_torch.__file__ = os.path.join(_mock_temp_dir, 'torch', '__init__.py')
+sys.modules['torch'] = mock_torch
+
+mock_cv2 = MagicMock()
+mock_cv2.__file__ = os.path.join(_mock_temp_dir, 'cv2', '__init__.py')
+mock_cv2.setNumThreads = MagicMock()
+sys.modules['cv2'] = mock_cv2
+
+mock_numpy = MagicMock()
+mock_numpy.__file__ = os.path.join(_mock_temp_dir, 'numpy', '__init__.py')
+sys.modules['numpy'] = mock_numpy
+
+mock_pil = MagicMock()
+mock_pil.__file__ = os.path.join(_mock_temp_dir, 'PIL', '__init__.py')
+mock_pil.Image = MagicMock()
+mock_pil.ImageFilter = MagicMock()
+sys.modules['PIL'] = mock_pil
+sys.modules['PIL.Image'] = mock_pil.Image
+sys.modules['PIL.ImageFilter'] = mock_pil.ImageFilter
+
+mock_skimage = MagicMock()
+mock_skimage.__file__ = os.path.join(_mock_temp_dir, 'skimage', '__init__.py')
+mock_skimage.measure = MagicMock()
+mock_skimage.measure.label = MagicMock()
+mock_skimage.measure.regionprops = MagicMock()
+sys.modules['skimage'] = mock_skimage
+sys.modules['skimage.measure'] = mock_skimage.measure
+
+mock_piexif = MagicMock()
+mock_piexif.__file__ = os.path.join(_mock_temp_dir, 'piexif', '__init__.py')
+sys.modules['piexif'] = mock_piexif

--- a/tests/wildcards/test_error_reporting.py
+++ b/tests/wildcards/test_error_reporting.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Unit Tests for Wildcard Error Reporting
+
+Tests that per-file error handling works correctly in wildcard loading,
+ensuring bad files don't crash the loader and valid files continue to load.
+"""
+import sys
+import os
+import tempfile
+
+# Add parent directory to path
+test_dir = os.path.dirname(os.path.abspath(__file__))
+impact_pack_dir = os.path.dirname(test_dir)
+sys.path.insert(0, impact_pack_dir)
+
+# Add modules/impact directory to path for direct import
+modules_impact_dir = os.path.join(test_dir, '..', '..', 'modules', 'impact')
+sys.path.insert(0, modules_impact_dir)
+
+# Import wildcards directly to avoid triggering root __init__.py
+import wildcards
+
+
+def test_yaml_file_with_null_bytes():
+    """Test that YAML file with null bytes doesn't crash loader"""
+    print("=" * 60)
+    print("TEST 1: YAML file with null bytes (AppleDouble-like)")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a YAML file with null bytes (like AppleDouble header)
+        bad_yaml = os.path.join(tmpdir, "bad_file.yaml")
+        with open(bad_yaml, 'wb') as f:
+            f.write(b'\x00\x00\x00\x00\x00\x00\x00\x00')  # Null bytes
+            f.write(b'key: value\n')
+
+        # Try to load - should not crash, should return empty list or handle gracefully
+        try:
+            result = wildcards.load_yaml_wildcard(bad_yaml)
+            print(f"✓ load_yaml_wildcard returned: {result}")
+            # Should either return empty list or handle gracefully
+            assert isinstance(result, list), "Should return a list"
+            print("✓ YAML with null bytes handled gracefully")
+            print("\n✅ TEST 1 PASSED\n")
+        except Exception as e:
+            # If it raises, that's also acceptable as long as it's handled
+            print(f"✓ Exception raised (acceptable): {type(e).__name__}")
+            print("\n✅ TEST 1 PASSED\n")
+
+
+def test_txt_file_with_binary_content():
+    """Test that TXT file with binary content doesn't crash loader"""
+    print("=" * 60)
+    print("TEST 2: TXT file with binary content")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a TXT file with binary content
+        bad_txt = os.path.join(tmpdir, "bad_file.txt")
+        with open(bad_txt, 'wb') as f:
+            f.write(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR')  # PNG header
+            f.write(b'some text content\n')
+
+        # Try to load - should not crash
+        try:
+            result = wildcards.load_txt_wildcard(bad_txt)
+            print(f"✓ load_txt_wildcard returned: {result}")
+            assert isinstance(result, list), "Should return a list"
+            print("✓ TXT with binary content handled gracefully")
+            print("\n✅ TEST 2 PASSED\n")
+        except Exception as e:
+            print(f"✓ Exception raised (acceptable): {type(e).__name__}")
+            print("\n✅ TEST 2 PASSED\n")
+
+
+def test_error_message_contains_file_path():
+    """Test that error message contains specific file path"""
+    print("=" * 60)
+    print("TEST 3: Error message contains specific file path")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a file that will fail to parse
+        bad_file = os.path.join(tmpdir, "test_error.txt")
+        with open(bad_file, 'wb') as f:
+            f.write(b'\x00\x00\x00\x00invalid content')
+
+        # Capture logging output to check error message
+        import logging
+        import io
+
+        # Create a handler to capture log output
+        log_capture = io.StringIO()
+        handler = logging.StreamHandler(log_capture)
+        handler.setLevel(logging.WARNING)
+
+        # Get the logger and add our handler
+        logger = logging.getLogger('modules.impact.wildcards')
+        original_level = logger.level
+        logger.setLevel(logging.WARNING)
+        logger.addHandler(handler)
+
+        try:
+            # This should trigger a warning
+            result = wildcards.load_txt_wildcard(bad_file)
+
+            # Get the captured log
+            log_output = log_capture.getvalue()
+            print(f"✓ Log output: {log_output}")
+
+            # Check if file path appears in warning
+            if log_output:
+                assert "test_error.txt" in log_output or bad_file in log_output, \
+                    f"Error message should contain file path, got: {log_output}"
+                print("✓ Error message contains file path")
+            else:
+                print("✓ No warning logged (file handled silently)")
+
+            print("\n✅ TEST 3 PASSED\n")
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(original_level)
+
+
+def test_valid_files_load_after_bad_files():
+    """Test that valid files still load after bad files are skipped"""
+    print("=" * 60)
+    print("TEST 4: Valid files load after bad files are skipped")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create multiple files - some bad, some good
+        bad_file1 = os.path.join(tmpdir, "bad1.txt")
+        good_file = os.path.join(tmpdir, "good.txt")
+        bad_file2 = os.path.join(tmpdir, "bad2.yaml")
+        good_yaml = os.path.join(tmpdir, "good.yaml")
+
+        # Bad files
+        with open(bad_file1, 'wb') as f:
+            f.write(b'\x00\x00\x00\x00binary junk')
+
+        with open(bad_file2, 'wb') as f:
+            f.write(b'\x00\x00\x00\x00corrupt')
+
+        # Good files
+        with open(good_file, 'w') as f:
+            f.write("option1\noption2\noption3\n")
+
+        with open(good_yaml, 'w') as f:
+            f.write("colors:\n  - red\n  - blue\n  - green\n")
+
+        # Try to load the good files specifically
+        good_txt_result = wildcards.load_txt_wildcard(good_file)
+        print(f"✓ Good TXT file loaded: {good_txt_result}")
+        assert len(good_txt_result) == 3, f"Expected 3 options, got {len(good_txt_result)}"
+        assert "option1" in good_txt_result
+
+        good_yaml_result = wildcards.load_yaml_wildcard(good_yaml)
+        print(f"✓ Good YAML file loaded: {good_yaml_result}")
+        assert len(good_yaml_result) > 0, "YAML should have returned options"
+
+        print("✓ Valid files load correctly after bad files")
+        print("\n✅ TEST 4 PASSED\n")
+
+
+def test_on_demand_mode_error_handling():
+    """Test both on_demand=True and on_demand=False modes work"""
+    print("=" * 60)
+    print("TEST 5: on_demand mode error handling")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a mix of good and bad files
+        good_file = os.path.join(tmpdir, "valid.txt")
+        bad_file = os.path.join(tmpdir, "corrupt.txt")
+
+        with open(good_file, 'w') as f:
+            f.write("good_option1\ngood_option2\n")
+
+        with open(bad_file, 'wb') as f:
+            f.write(b'\x00\x00\x00\x00broken')
+
+        # Test on_demand=False mode (immediate loading)
+        print("Testing on_demand=False mode...")
+        wildcards.wildcard_dict.clear()
+        wildcards.read_wildcard_dict(tmpdir, on_demand=False)
+
+        # Check that good file was loaded
+        valid_key = wildcards.wildcard_normalize("valid")
+        if valid_key in wildcards.wildcard_dict:
+            data = wildcards.wildcard_dict[valid_key]
+            if isinstance(data, wildcards.LazyWildcardLoader):
+                data = data.get_data()
+            print(f"✓ on_demand=False: valid.txt loaded as: {data}")
+            assert len(data) == 2
+
+        print("✓ on_demand=False mode works")
+
+        # Test on_demand=True mode (lazy loading)
+        print("Testing on_demand=True mode...")
+        wildcards.wildcard_dict.clear()
+        wildcards.read_wildcard_dict(tmpdir, on_demand=True)
+
+        valid_key = wildcards.wildcard_normalize("valid")
+        if valid_key in wildcards.wildcard_dict:
+            loader = wildcards.wildcard_dict[valid_key]
+            assert isinstance(loader, wildcards.LazyWildcardLoader), "Should be LazyWildcardLoader"
+            data = loader.get_data()
+            print(f"✓ on_demand=True: valid.txt loaded as: {data}")
+            assert len(data) == 2
+
+        print("✓ on_demand=True mode works")
+
+        # Both modes should handle errors gracefully without crashing
+        print("\n✅ TEST 5 PASSED\n")
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 60)
+    print("WILDCARD ERROR REPORTING TESTS")
+    print("=" * 60 + "\n")
+
+    test_yaml_file_with_null_bytes()
+    test_txt_file_with_binary_content()
+    test_error_message_contains_file_path()
+    test_valid_files_load_after_bad_files()
+    test_on_demand_mode_error_handling()
+
+    print("=" * 60)
+    print("ALL TESTS PASSED!")
+    print("=" * 60 + "\n")


### PR DESCRIPTION
Instead of a generic error message, this will identify to the user exactly which wildcard files cannot be processed successfully, so they can address.