### PR TITLE
fix: preserve existing canvas background hook

### DIFF
--- a/js/mask-rect-area-advanced.js
+++ b/js/mask-rect-area-advanced.js
@@ -1,5 +1,31 @@
 import { app } from "../../scripts/app.js";
 import { readLinkedNumber, getDrawColor, computeCanvasSize } from "./common.js";
+
+const MASK_RECT_AREA_BACKGROUND_HOOK = "__impactMaskRectAreaOnDrawBackgroundHook";
+
+function moveMaskRectAreaWidgetsOffscreen() {
+    for (const node of app.graph?._nodes || []) {
+        for (const widget of node.widgets || []) {
+            if (Object.hasOwn(widget, "canvas")) {
+                widget.canvas.style.left = "-8000px";
+                widget.canvas.style.position = "absolute";
+            }
+        }
+    }
+}
+
+function ensureMaskRectAreaBackgroundHook() {
+    if (app.canvas[MASK_RECT_AREA_BACKGROUND_HOOK]) {
+        return;
+    }
+
+    const onDrawBackground = app.canvas.onDrawBackground;
+    app.canvas.onDrawBackground = function (...args) {
+        onDrawBackground?.apply(this, args);
+        moveMaskRectAreaWidgetsOffscreen();
+    };
+    app.canvas[MASK_RECT_AREA_BACKGROUND_HOOK] = true;
+}
 function showPreviewCanvas(node, app) {
 
     const widget = {
@@ -193,21 +219,7 @@ function showPreviewCanvas(node, app) {
     document.body.appendChild(widget.canvas);
     node.addCustomWidget(widget);
 
-    app.canvas.onDrawBackground = function () {
-        // Draw node isnt fired once the node is off the screen
-        // if it goes off screen quickly, the input may not be removed
-        // this shifts it off screen so it can be moved back if the node is visible.
-        for (let n in app.graph._nodes) {
-            n = app.graph._nodes[n];
-            for (let w in n.widgets) {
-                let wid = n.widgets[w];
-                if (Object.hasOwn(wid, "canvas")) {
-                    wid.canvas.style.left = -8000 + "px";
-                    wid.canvas.style.position = "absolute";
-                }
-            }
-        }
-    };
+    ensureMaskRectAreaBackgroundHook();
 
     node.onResize = function (size) {
         computeCanvasSize(node, size, 220, 240);
@@ -456,4 +468,3 @@ function syncLinkedInputsToPropertiesAdvanced(node) {
 
     return changed;
 }
-

--- a/js/mask-rect-area.js
+++ b/js/mask-rect-area.js
@@ -1,5 +1,31 @@
 import { app } from "../../scripts/app.js";
 import { readLinkedNumber, getDrawColor, computeCanvasSize } from "./common.js";
+
+const MASK_RECT_AREA_BACKGROUND_HOOK = "__impactMaskRectAreaOnDrawBackgroundHook";
+
+function moveMaskRectAreaWidgetsOffscreen() {
+    for (const node of app.graph?._nodes || []) {
+        for (const widget of node.widgets || []) {
+            if (Object.hasOwn(widget, "canvas")) {
+                widget.canvas.style.left = "-8000px";
+                widget.canvas.style.position = "absolute";
+            }
+        }
+    }
+}
+
+function ensureMaskRectAreaBackgroundHook() {
+    if (app.canvas[MASK_RECT_AREA_BACKGROUND_HOOK]) {
+        return;
+    }
+
+    const onDrawBackground = app.canvas.onDrawBackground;
+    app.canvas.onDrawBackground = function (...args) {
+        onDrawBackground?.apply(this, args);
+        moveMaskRectAreaWidgetsOffscreen();
+    };
+    app.canvas[MASK_RECT_AREA_BACKGROUND_HOOK] = true;
+}
 function showPreviewCanvas(node, app) {
 
     const widget = {
@@ -186,21 +212,7 @@ function showPreviewCanvas(node, app) {
     document.body.appendChild(widget.canvas);
     node.addCustomWidget(widget);
 
-    app.canvas.onDrawBackground = function () {
-        // Draw node isnt fired once the node is off the screen
-        // if it goes off screen quickly, the input may not be removed
-        // this shifts it off screen so it can be moved back if the node is visible.
-        for (let n in app.graph._nodes) {
-            n = app.graph._nodes[n];
-            for (let w in n.widgets) {
-                let wid = n.widgets[w];
-                if (Object.hasOwn(wid, "canvas")) {
-                    wid.canvas.style.left = -8000 + "px";
-                    wid.canvas.style.position = "absolute";
-                }
-            }
-        }
-    };
+    ensureMaskRectAreaBackgroundHook();
 
     node.onResize = function (size) {
         computeCanvasSize(node, size, 200, 200);


### PR DESCRIPTION
## Summary

This change avoids overwriting `app.canvas.onDrawBackground` when the mask rect preview canvas widgets are installed.

## Tested environment

- ComfyUI core: `v0.24.0`
- ComfyUI commit: `f49bdb65`
- comfyui-frontend-package: `1.44.19`

Validated in a multi-extension setup on the classic / non-Vue node path.

## Problem

The current code directly assigns `app.canvas.onDrawBackground`, which means the previous global handler is lost.

In a multi-extension setup, this can interfere with other extensions that also depend on the canvas background hook for DOM/canvas widget cleanup and positioning.

## Changes

- preserve the existing `app.canvas.onDrawBackground`
- wrap it instead of replacing it
- run the mask rect preview off-screen cleanup after the previous handler

Affected files:
- `mask-rect-area.js`
- `mask-rect-area-advanced.js`

## Why this helps

This keeps the current preview cleanup behavior while improving compatibility with other extensions that share the same global canvas hook.

## Manual validation

Validated manually in a setup with multiple frontend extensions that use custom DOM/canvas widgets at the same time.