### PR TITLE
fix: SEGSLabelFilterDetailerHookProvider - remove SEGS input requirement

### DIFF
--- a/modules/impact/hook_nodes.py
+++ b/modules/impact/hook_nodes.py
@@ -49,7 +49,6 @@ class SEGSLabelFilterDetailerHookProvider:
     @classmethod
     def INPUT_TYPES(s):
         return {"required": {
-                        "segs": ("SEGS", ),
                         "preset": (['all'] + defs.detection_labels,),
                         "labels": ("STRING", {"multiline": True, "placeholder": "List the types of segments to be allowed, separated by commas"}),
                      },


### PR DESCRIPTION
<img width="2403" height="1171" alt="Comfy Desktop v1 0 22 2026-06-20 16_47_50" src="https://github.com/user-attachments/assets/08b6eb7d-be0f-446c-b658-efaad71cd760" />

The SEGSLabelFilterDetailerHookProvider node erroneously requires a SEGS input.

If you run it without you get the error: `SEGSLabelFilterDetailerHookProvider is missing a required input: segs`

If you attach one the error becomes: `TypeError: SEGSLabelFilterDetailerHookProvider.doit() got an unexpected keyword argument 'segs'`

The node doesn't actually want a SEGS input at all.

**Fix**: remove the erroneous required SEGS input