### PR TITLE
Fix wildcard processing with negative seeds and restore global random state

### DIFF
--- a/modules/impact/wildcards.py
+++ b/modules/impact/wildcards.py
@@ -535,9 +535,20 @@ def process_comment_out(text):
 
 
 def process(text, seed=None):
+    # Restore the global random state afterwards so seeding here does not affect other nodes.
+    state = random.getstate()
+    try:
+        return _process(text, seed)
+    finally:
+        random.setstate(state)
+
+
+def _process(text, seed=None):
     text = process_comment_out(text)
 
     if seed is not None:
+        # np.random.default_rng() only accepts non negative seeds.
+        seed = int(seed) & 0xFFFFFFFFFFFFFFFF
         random.seed(seed)
     random_gen = np.random.default_rng(seed)
 


### PR DESCRIPTION
Two small fixes in `wildcards.process()`.

`np.random.default_rng()` raises `ValueError` on a negative seed. Seed sources that can go negative do exist, for example a primitive whose minimum is negative, or a seed node set to -1. When that happens the exception reaches the prompt handler, wildcard population is skipped and the node keeps its previous populated text. The traceback is logged, but in the UI it just looks like the same prompt was generated again. Masking the seed to 64 bits keeps those sources working.

`process()` also seeds the global `random` module and leaves it that way. Nodes that draw from the global RNG afterwards then continue from a stream derived from that seed, which can make things that should be random repeat. Saving and restoring the state keeps the seeding local without changing behaviour inside the function.
