### PR TITLE
Fix ImpactSwitch workflow reload on frontend >= 1.47

### DIFF
--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -634,11 +634,6 @@ app.registerExtension({
 						// NOTE: node is undefined when subgraph editing mode
 						if(node) {
 							let origin_type = node.outputs[link_info.origin_slot]?.type;
-							if(link_info.target_slot == 0 && this.inputs.length > 3) {  // NOTE: widgets are regarded as input since new front
-									origin_type = this.inputs[1].type;
-									node.connect(link_info.origin_slot, node.id, 'input1');
-							}
-
 							if(origin_type == '*' && app.graph.getNodeById(link_info.origin_id).slots[link_info.origin_slot].type != '*') {
 								this.disconnectInput(link_info.target_slot);
 								return;


### PR DESCRIPTION
Fixes #1223. Removes the obsolete slot-0 reconnect that passes the origin node ID to node.connect(). Frontend >= 1.47 expects a node object, causing TypeError: t.findInputSlot is not a function while reloading workflows. The existing type-propagation code below handles the connection. Validated with node --check and a running ComfyUI 0.32.0 instance.