### PR TITLE
Fix FaceDetailer 5D tensor crash with video-VAE models (Wan/Qwen/Krea)

### DIFF
--- a/modules/impact/utils.py
+++ b/modules/impact/utils.py
@@ -127,6 +127,8 @@ def general_tensor_resize(image, w: int, h: int):
 # TODO: Sadly, we need LANCZOS
 LANCZOS = (Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.LANCZOS)
 def tensor_resize(image, w: int, h: int):
+    if image.ndim == 5:  # video-VAE (Wan/Qwen/Krea) decode leaks a size-1 temporal axis
+        image = image.reshape(-1, *image.shape[-3:])
     _tensor_check_image(image)
     if image.shape[3] >= 3:
         scaled_images = TensorBatchBuilder()


### PR DESCRIPTION
## Problem

`FaceDetailer` (and any `DetailerForEach`-based node) crashes with:

```
ValueError: Expected NHWC tensor, but found 5 dimensions
  File ".../modules/impact/core.py", line 390, in enhance_detail
    refined_image = tensor_resize(refined_image, w, h)
  File ".../modules/impact/utils.py", in tensor_resize -> _tensor_check_image
```

whenever the detailer `vae` is a **video VAE** — Wan 2.1/2.2, Qwen-Image, or Krea 2. This is the same failure reported in #1066.

## Root cause

Core `nodes.VAEDecode` normalizes video-VAE output by collapsing the temporal axis to 4D. However, `core.enhance_detail` decodes the refined face crop through `nodes.VAEDecodeTiled().decode(...)` / raw `vae.decode(...)`, which return the raw **5D `[B, T, H, W, C]`** tensor (T=1 for stills). `tensor_resize` then calls `_tensor_check_image`, which hard-rejects `ndim != 4`.

The input image feeding FaceDetailer is fine (it comes from core `VAEDecode`, already 4D) — only the internal re-decode leaks the 5D tensor, which is why the crash is deep inside `enhance_detail` rather than at the node input.

## Fix

Collapse a size-1 temporal axis to 4D in `tensor_resize`, the common choke point every detailer path flows through:

```python
def tensor_resize(image, w: int, h: int):
    if image.ndim == 5:  # video-VAE (Wan/Qwen/Krea) decode leaks a size-1 temporal axis
        image = image.reshape(-1, *image.shape[-3:])
    _tensor_check_image(image)
    ...
```

`reshape(-1, *image.shape[-3:])` folds the temporal axis into batch, so a still `[B, 1, H, W, C]` becomes `[B, H, W, C]` and the rest of the pipeline is unchanged for the 4D case.

## Testing

Verified on ComfyUI v0.26.2 with the Impact Pack FaceDetailer node:

- **Krea 2** (Qwen-Image VAE), portrait stills — before: `Expected NHWC tensor, but found 5 dimensions`; after: FaceDetailer completes and returns the detailed image.
- Regression check on standard 4D VAEs (SDXL / Z-Image / Flux): unchanged behavior (guard is a no-op for `ndim == 4`).

Fixes #1066
