### PR TITLE
fix(sam-editor): stop importing removed extensions/core/clipspace.js

### DIFF
--- a/js/impact-sam-editor.js
+++ b/js/impact-sam-editor.js
@@ -2,7 +2,17 @@ import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 import { ComfyDialog, $el } from "../../scripts/ui.js";
 import { ComfyApp } from "../../scripts/app.js";
-import { ClipspaceDialog } from "../../extensions/core/clipspace.js";
+// The frontend no longer serves extensions/core/clipspace.js (absent as of
+// comfyui-frontend-package 1.49.6 - ClipspaceDialog is module-local in the
+// bundle and is exposed on neither window nor comfyAPI). Statically importing
+// it 404s, which aborts this entire module and silently drops "Open in SAM
+// Detector" from the node context menu. Resolve it if a future frontend
+// exposes it again, otherwise degrade to no-ops: the context-menu entry
+// works, only the button inside the clipspace dialog is not added.
+const ClipspaceDialog = window.comfyAPI?.clipspace?.ClipspaceDialog ?? {
+	invalidatePreview() {},
+	registerButton() {},
+};
 
 function addMenuHandler(nodeType, cb) {
 	const getOpts = nodeType.prototype.getExtraMenuOptions;


### PR DESCRIPTION
Fixes #1214. Also removes the `clipspace.js` half of #1215, and supersedes the `impact-sam-editor.js` portion of #1207.

## Problem

`js/impact-sam-editor.js:5` statically imports `../../extensions/core/clipspace.js`. That path 404s on current frontends: `comfyui-frontend-package` 1.49.6 ships a legacy shim directory at `static/extensions/core/` containing only `editAttention.js`, `groupNode.js`, `textPreviewWidgets.js`, `widgetInputs.js` and `widgetValuePropagation.js`. There is no `clipspace.js` anywhere under `static/`.

A static import of a 404 aborts the whole module, so `app.registerExtension({ name: "Comfy.Impact.SAMEditor" })` at line 611 never runs and **"Open in SAM Detector" is never added to the node context menu**. The frontend loads each extension as `try { await import(...) } catch (t) { console.error('Error loading extension', e, t) }`, so the only visible trace is a single red line in devtools — which is why this reads as a silently missing menu entry.

## Why not the shim in #1207

`ClipspaceDialog` cannot be resolved off `window.comfyAPI`. It is a module-local class inside `assets/core-*.js`, exposed on neither `window` nor `comfyAPI` — the only global the core Clipspace extension publishes is `app.openClipspace()`. So the fallback there:

```js
if (window?.comfyAPI?.clipspace?.ClipspaceDialog) { ... }
else { ({ ClipspaceDialog } = await import("../../extensions/core/clipspace.js")); }
```

always takes the `else`, the dynamic import rejects on the same 404, and the rejected top-level await still fails module evaluation. The `ui.js` shims in that PR are unaffected, since `comfyAPI.ui` does exist.

## This change

Bind `ClipspaceDialog` defensively instead of importing it — the real class is picked up automatically if a future frontend exposes it on `comfyAPI`, otherwise the two call sites no-op:

```js
const ClipspaceDialog = window.comfyAPI?.clipspace?.ClipspaceDialog ?? {
	invalidatePreview() {},
	registerButton() {},
};
```

**Trade-off:** this gives up `ClipspaceDialog.registerButton("Impact SAM Detector", ...)` (the button inside the clipspace/mask editor) and the `invalidatePreview()` refresh. Both are already non-functional today, since the module does not load at all — so this is strictly a gain until the frontend exposes the class again.

## Testing

ComfyUI 0.34.0, `comfyui-frontend-package` 1.49.6, Impact-Pack `429d015` (V8.28.3), Windows portable.

**Before:** `GET /extensions/core/clipspace.js` → 404, `Comfy.Impact.SAMEditor` absent from `app.extensions`, one `Error loading extension .../impact-sam-editor.js` in the devtools console, no context-menu entry.

**After**, verified in a headless Edge (Chromium) session driven over CDP against the running server:

- All three static imports the module declares resolve **200** (`/scripts/api.js`, `/scripts/app.js`, `/scripts/ui.js`).
- `app.extensions.some(e => e.name === "Comfy.Impact.SAMEditor")` → `true`; Impact-Pack registers both `Comfy.Impact.img` and `Comfy.Impact.SAMEditor` out of 50 loaded extensions.
- Zero `Error loading extension` entries in the console.
- Added a `LoadImage` node and dispatched a real right-click on it with `Input.dispatchMouseEvent` — not by calling the handler directly — then read the rendered `.litecontextmenu`:

  ```
  ["Open in SAM Detector", "Open Image", "Copy Image", "Save Image",
   "Convert to Subgraph", ..., "Open in MaskEditor | Image Canvas", ...]
  ```

`node --check` passes on the module parsed as ESM. CRLF line endings and tab indentation preserved.

Note that this does not quiet the client-side `[ComfyUI Deprecated] Importing from "scripts/ui.js"` warnings the remaining shims emit — those belong to #1207.
