### PR TITLE
Fix TypeError in Switch (Any) when a connected node is deleted

### DIFF
--- a/js/impact-pack.js
+++ b/js/impact-pack.js
@@ -636,7 +636,7 @@ app.registerExtension({
 							let origin_type = node.outputs[link_info.origin_slot]?.type;
 							if(link_info.target_slot == 0 && this.inputs.length > 3) {  // NOTE: widgets are regarded as input since new front
 									origin_type = this.inputs[1].type;
-									node.connect(link_info.origin_slot, node.id, 'input1');
+									node.connect(link_info.origin_slot, node, 'input1');
 							}
 
 							if(origin_type == '*' && app.graph.getNodeById(link_info.origin_id).slots[link_info.origin_slot].type != '*') {


### PR DESCRIPTION
### Problem

Deleting a node that is wired into a wildcard-typed `Switch (Any)` (`ImpactSwitch`) throws in the browser and aborts the delete partway through:

```
TypeError: target_node.findInputSlot is not a function
    at ComfyNode.connect
    at nodeType.onConnectionsChange (impact-pack.js:639)
    at ComfyNode.onConnectionsChange
    at ComfyNode.disconnectInput
    at LGraph.remove
    at LGraphCanvas.deleteSelected
```

Reproduced on ComfyUI 0.34.0 with `comfyui-frontend-package` 1.49.6.

### Cause

`js/impact-pack.js:639` calls:

```js
node.connect(link_info.origin_slot, node.id, 'input1');
```

This was valid when litegraph node ids were numbers: `connect()` resolves a legacy id form via `getNodeById()`.

In current ComfyUI_frontend, `NodeId` is a string-branded type and `LGraphNode.id` is always a string. `connect()` still guards that legacy path with `typeof target_node === 'number'`, so a string id falls through unresolved and is then used as if it were a node, producing the `TypeError`.

### Fix

Pass the node object directly. This restores the previous behaviour exactly, since the numeric id resolved to this same node.

### Why it is worth fixing promptly

The throw is not contained by the caller. It escapes `LGraph.remove()` and `LGraphCanvas.deleteSelected()`, which emits its `before-change` / `after-change` pair without a `try`/`finally`. The closing event never fires, so the editor's change-transaction counter stays raised. From that point on, for the rest of the browser session, the frontend silently stops recording undo history, stops persisting drafts, and stops flushing canvas state before a workflow tab switch or save. The visible result is lost work with no error beyond the initial toast.

I am filing that containment gap separately against ComfyUI_frontend. This PR only addresses the call that throws.

### Note for the maintainer

I kept this minimal and behaviour-preserving. It is possible the intended target was the switch node (`this`) rather than the origin node, which would make this branch actually reconnect the link to `input1` instead of being an effective no-op. I did not change that, since you would know the intent. Happy to adjust if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
